### PR TITLE
docs: rebuild the docs site on a real design system

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -4,7 +4,15 @@ BrowserControl is an open-source MCP server that gives AI agents a real browser 
 
 ## Mission
 
-> Make this MCP server great, popular, well-used, and better.
+> Give AI agents a better way to use a browser — one they can actually see,
+> running on your machine, free for anyone to use.
+
+Agents are asked to work on the web every day, and most of the tooling still
+hands them a DOM and hopes for the best. BrowserControl exists to close that
+gap: show the agent the page, let it point at what it wants, and keep the whole
+loop local, private, and free. Every design decision is measured against that —
+does it make an agent more capable in a browser, and does it stay out of the
+user's way?
 
 ## Origin
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,342 +3,360 @@ hide:
   - navigation
   - toc
 ---
-
-<div class="bc-page" markdown>
-
-<!-- ============================================================
-     HERO
-     ============================================================ -->
-<div class="bc-hero" aria-label="BrowserControl introduction">
-  <div class="bc-hero-copy">
-    <span class="bc-eyebrow">
-      <span class="bc-eyebrow-dot" aria-hidden="true"></span>
-      Vision-first MCP browser automation
-    </span>
-
-    <h1 class="bc-hero-headline">
-      Your agent <span class="bc-mark-red">sees the page.</span><br>
-      Then clicks the number.
-    </h1>
-
-    <p class="bc-hero-lede">
-      BrowserControl is a local MCP server that gives any AI agent a real
-      browser it can <strong>see</strong>, <strong>click</strong>,
-      <strong>type</strong>, and <strong>debug</strong> &mdash; using a
-      vision-first <strong>Set of Marks</strong> overlay. No selectors. No
-      cloud. No API bill.
-    </p>
-
-    <div class="bc-hero-cta">
-      <a href="getting-started/index.md" class="md-button md-button--primary">
-        Get started
-      </a>
-      <a href="https://github.com/adityasasidhar/browsercontrol"
-         class="md-button" rel="noopener">
-        View on GitHub
-      </a>
+<div class="bc-page">
+  <!-- ===================================================================
+       HERO
+       =================================================================== -->
+  <section class="bc-hero">
+    <div class="bc-wrap bc-hero-inner">
+      <div class="bc-hero-copy">
+        <a class="bc-pill" href="concepts/set-of-marks/">
+          <span class="bc-pill-tag">SoM</span>
+          <span>What Set of Marks actually does</span>
+          <span class="bc-pill-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <h1 class="bc-h1">Your agent <span class="bc-marked">sees</span> the page.<br>Then clicks the number.</h1>
+        <p class="bc-hero-lede">BrowserControl is a local MCP server that hands any AI agent a real Chromium browser it can <strong>see</strong>, <strong>click</strong>, <strong>type</strong> into, and <strong>debug</strong> — through numbered marks drawn over every interactive element. No selectors. No cloud. No API bill.</p>
+        <div class="bc-cta-row">
+          <a class="bc-btn bc-btn--primary" href="getting-started/">
+            Get started
+            <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2.5 8h11M9 3.5 13.5 8 9 12.5"/></svg>
+          </a>
+          <a class="bc-btn bc-btn--ghost" href="https://github.com/adityasasidhar/browsercontrol" rel="noopener">
+            <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+            View on GitHub
+          </a>
+        </div>
+        <div class="bc-hero-cmd"><span class="bc-prompt" aria-hidden="true">$</span><code>pip install browsercontrol</code></div>
+        <ul class="bc-trust">
+          <li><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8.5 3.2 3.2L13 5"/></svg> Runs 100% on your machine</li>
+          <li><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8.5 3.2 3.2L13 5"/></svg> No LLM API key</li>
+          <li><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8.5 3.2 3.2L13 5"/></svg> MIT licensed</li>
+          <li><svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 8.5 3.2 3.2L13 5"/></svg> Python 3.11+</li>
+        </ul>
+      </div>
+      <!-- The hero visual is real markup, not a screenshot, so it follows
+           the reader's colour scheme and stays crisp at any resolution. -->
+      <div class="bc-hero-visual">
+        <div class="bc-scope">
+          <div class="bc-window">
+            <div class="bc-window-bar">
+              <span class="bc-dot"></span><span class="bc-dot"></span><span class="bc-dot"></span>
+              <span class="bc-window-url">app.example.com/sign-in</span>
+              <span class="bc-window-tag">SoM</span>
+            </div>
+            <div class="bc-viewport" role="img" aria-label="A browser viewport with five interactive elements outlined in red and numbered one through five: the search field, a nav link, the email field, the password field, and the Sign in button.">
+              <span class="bc-topbar"></span>
+              <span class="bc-sk bc-sk--round" style="left:4%;top:4%;width:5%;height:5%"></span>
+              <span class="bc-sk" style="left:12%;top:5.2%;width:7%;height:2.6%"></span>
+              <span class="bc-sk" style="left:21%;top:5.2%;width:6%;height:2.6%"></span>
+              <span class="bc-sk" style="left:29%;top:5.2%;width:8%;height:2.6%"></span>
+              <span class="bc-sk bc-sk--field" style="left:58%;top:3.5%;width:26%;height:6%"></span>
+              <span class="bc-sk bc-sk--round" style="left:88%;top:3.5%;width:6%;height:6%"></span>
+              <span class="bc-panel"></span>
+              <span class="bc-sk bc-sk--strong" style="left:30%;top:30%;width:24%;height:4%"></span>
+              <span class="bc-sk" style="left:30%;top:36.5%;width:40%;height:2.2%"></span>
+              <span class="bc-sk bc-sk--field" style="left:30%;top:43%;width:40%;height:7%"></span>
+              <span class="bc-sk bc-sk--field" style="left:30%;top:53%;width:40%;height:7%"></span>
+              <span class="bc-sk bc-sk--btn" style="left:30%;top:64%;width:40%;height:7.5%"></span>
+              <span class="bc-sk" style="left:36%;top:76.5%;width:28%;height:2.2%"></span>
+              <span class="bc-mark" data-n="1" style="--x:57.5%;--y:3%;--w:27%;--h:7%;--i:0"></span>
+              <span class="bc-mark" data-n="2" style="--x:11%;--y:4.6%;--w:9%;--h:3.8%;--i:1"></span>
+              <span class="bc-mark" data-n="3" style="--x:29%;--y:42.2%;--w:42%;--h:8.6%;--i:2"></span>
+              <span class="bc-mark" data-n="4" style="--x:29%;--y:52.2%;--w:42%;--h:8.6%;--i:3"></span>
+              <span class="bc-mark" data-n="5" style="--x:29%;--y:63.2%;--w:42%;--h:9.1%;--i:4"></span>
+            </div>
+          </div>
+          <div class="bc-map">
+            <div class="bc-map-head"><span>element_map</span><b>5</b></div>
+            <ul class="bc-map-list">
+              <li style="--i:0"><span class="n">1</span><span class="t">input</span><span class="l">Search or jump to&hellip;</span></li>
+              <li style="--i:1"><span class="n">2</span><span class="t">a</span><span class="l">Pull requests</span></li>
+              <li style="--i:2"><span class="n">3</span><span class="t">input</span><span class="l">Email address</span></li>
+              <li style="--i:3"><span class="n">4</span><span class="t">input</span><span class="l">Password</span></li>
+              <li style="--i:4"><span class="n">5</span><span class="t">button</span><span class="l">Sign in</span></li>
+            </ul>
+            <div class="bc-map-call"><span class="arrow">&rsaquo;</span> <span class="fn">click(5)</span><br><span class="ok">&check; clicked "Sign in"</span></div>
+          </div>
+        </div>
+      </div>
     </div>
-
-    <div class="bc-trust-row" aria-label="Trust signals">
-      <span><svg viewBox="0 0 16 16" aria-hidden="true"><path fill="currentColor" d="M8 1.5 2.5 4v4c0 3.4 2.4 5.7 5.5 6.5 3.1-.8 5.5-3.1 5.5-6.5V4L8 1.5Z"/></svg> 100% local</span>
-      <span><svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M5 8.5 7 10.5 11 6.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg> MIT licensed</span>
-      <span><svg viewBox="0 0 16 16" aria-hidden="true"><rect x="2.5" y="3.5" width="11" height="9" rx="1.5" fill="none" stroke="currentColor" stroke-width="1.6"/><path d="M5.5 6.5 8 8.5 10.5 6.5" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg> Python 3.11+</span>
-      <span><svg viewBox="0 0 16 16" aria-hidden="true"><circle cx="8" cy="8" r="2.5" fill="currentColor"/><circle cx="8" cy="8" r="6.5" fill="none" stroke="currentColor" stroke-width="1.4"/></svg> MCP-compatible</span>
-    </div>
-  </div>
-
-  <div class="bc-hero-visual">
-    <img src="assets/demo.svg"
-         alt="Annotated screenshot of a browser with five red numbered Set of Marks, beside the textual element map returned to the agent and a click(5) action card showing the successful Sign in click."
-         class="bc-demo">
-  </div>
-</div>
-
-<!-- ============================================================
-     BADGE STRIP — replaces loose shields.io row
-     ============================================================ -->
-<div class="bc-badge-strip" aria-label="Project status">
-  <a class="bc-badge" href="https://pypi.org/project/browsercontrol/" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    PyPI &middot; 0.1.4
-  </a>
-  <a class="bc-badge bc-badge--red" href="https://www.python.org/downloads/" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    Python 3.11+
-  </a>
-  <a class="bc-badge bc-badge--violet" href="https://opensource.org/licenses/MIT" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    MIT License
-  </a>
-  <a class="bc-badge" href="https://modelcontextprotocol.io/" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    MCP Compatible
-  </a>
-  <a class="bc-badge bc-badge--ink" href="https://github.com/adityasasidhar/browsercontrol/actions" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    CI passing
-  </a>
-  <a class="bc-badge" href="https://github.com/adityasasidhar/browsercontrol/stargazers" rel="noopener">
-    <span class="bc-badge-dot" aria-hidden="true"></span>
-    Star on GitHub
-  </a>
-</div>
-
-<!-- ============================================================
-     THREE-STEP SoM EXPLANATION
-     ============================================================ -->
-<div class="bc-section">
-  <span class="bc-section-eyebrow">Set of Marks</span>
-  <h2 class="bc-section-title">See the page. Pick a number. Click.</h2>
-  <p class="bc-section-lede">
-    Every BrowserControl tool that touches the page returns the same shape:
-    an annotated screenshot with numbered red boxes over each interactive
-    element, plus a textual element map. The model picks a number. The click
-    resolves through <code>document.elementFromPoint()</code> so overlays and
-    sticky chrome never get in the way.
-  </p>
-
-  <div class="bc-steps">
-    <div class="bc-step">
-      <span class="bc-step-num">1</span>
-      <h3 class="bc-step-title">See</h3>
-      <p class="bc-step-body">
-        A screenshot is annotated with numbered red boxes over every
-        interactive element &mdash; inputs, links, buttons, even shadow-DOM
-        descendants and same-origin iframes.
-      </p>
-      <span class="bc-step-arrow" aria-hidden="true">&rarr;</span>
-    </div>
-    <div class="bc-step">
-      <span class="bc-step-num">2</span>
-      <h3 class="bc-step-title">Choose</h3>
-      <p class="bc-step-body">
-        A compact textual element map lists each numbered target with its tag
-        and label. The model picks a number &mdash; no selectors, no XPath,
-        no hallucinated <code>div.flex &gt; button:nth-child(3)</code>.
-      </p>
-      <span class="bc-step-arrow" aria-hidden="true">&rarr;</span>
-    </div>
-    <div class="bc-step">
-      <span class="bc-step-num">3</span>
-      <h3 class="bc-step-title">Act</h3>
-      <p class="bc-step-body">
-        The agent calls <code>click(5)</code>. BrowserControl resolves the
-        actual DOM element at the box center and drives Chromium. Cookies,
-        login state, and history all survive restarts.
-      </p>
+  </section>
+  <!-- ===================================================================
+       STAT STRIP
+       =================================================================== -->
+  <div class="bc-stats">
+    <div class="bc-wrap bc-stats-grid">
+      <div class="bc-stat">
+        <span class="bc-stat-num">~30</span>
+        <span class="bc-stat-label">MCP tools, every one returning a fresh annotated screenshot</span>
+      </div>
+      <div class="bc-stat">
+        <span class="bc-stat-num">7</span>
+        <span class="bc-stat-label">Categories: navigation, interaction, tabs, forms, content, devtools, recording</span>
+      </div>
+      <div class="bc-stat">
+        <span class="bc-stat-num"><em>$0</em></span>
+        <span class="bc-stat-label">Marginal cost per 1,000 browser actions</span>
+      </div>
+      <div class="bc-stat">
+        <span class="bc-stat-num">0</span>
+        <span class="bc-stat-label">Bytes of your browsing sent anywhere off-device</span>
+      </div>
     </div>
   </div>
-</div>
-
-<!-- ============================================================
-     PROOF PANEL — annotated screenshot + tool output
-     ============================================================ -->
-<div class="bc-section">
-  <span class="bc-section-eyebrow">Proof</span>
-  <h2 class="bc-section-title">One tool call. One annotated screenshot. One click.</h2>
-  <p class="bc-section-lede">
-    This is the literal shape BrowserControl returns from
-    <code>get_screenshot_with_summary()</code>: the marked-up page and the
-    element map the model reads. A subsequent <code>click(5)</code> lands on
-    the Sign in button.
-  </p>
-
-  <div class="bc-proof">
-    <div class="bc-proof-img">
-      <img src="assets/demo.svg"
-           alt="Annotated browser screenshot with five numbered red marks, beside the element map returned to the agent and a click(5) action card showing a successful Sign in click."
-           loading="lazy">
+  <!-- ===================================================================
+       THE LOOP
+       =================================================================== -->
+  <section class="bc-section bc-section--tint">
+    <div class="bc-wrap">
+      <div class="bc-head">
+        <p class="bc-eyebrow">The loop</p>
+        <h2 class="bc-h2">See the page. Pick a number. Act.</h2>
+        <p class="bc-lede">Every tool that touches the page returns the same two things: an annotated screenshot and a textual element map. The model reads pixels <em>and</em> labels, then names a number. Clicks resolve through <code>document.elementFromPoint()</code>, so sticky headers, overlays, and cookie banners never steal the hit.</p>
+      </div>
+      <div class="bc-steps">
+        <div class="bc-step">
+          <span class="bc-step-n">1</span>
+          <h3>See</h3>
+          <p>A screenshot comes back with numbered red boxes over every interactive element — inputs, links, buttons, open shadow-DOM descendants, and same-origin iframes with their coordinate offsets already applied.</p>
+        </div>
+        <div class="bc-step">
+          <span class="bc-step-n">2</span>
+          <h3>Choose</h3>
+          <p>Alongside it, a compact element map lists each mark with its tag and accessible label. The model picks a number — never a brittle <code>div.flex &gt; button:nth-child(3)</code> it hallucinated from stale HTML.</p>
+        </div>
+        <div class="bc-step">
+          <span class="bc-step-n">3</span>
+          <h3>Act</h3>
+          <p>The agent calls <code>click(5)</code>. BrowserControl resolves the live DOM node under that box, drives Chromium, and re-marks the new page. Cookies and login state survive restarts.</p>
+        </div>
+      </div>
+      <div class="bc-transcript">
+        <div class="bc-transcript-head">
+          <span class="bc-dot"></span><span class="bc-dot"></span><span class="bc-dot"></span>
+          <span class="sp">agent session</span>
+        </div>
+        <pre class="bc-transcript-body"><span class="a">agent</span>  <span class="c">&rsaquo;</span> <span class="f">navigate_to</span>(<span class="s">"https://app.example.com/sign-in"</span>)
+       <span class="c">&lsaquo; screenshot + element_map &mdash; <span class="m">5</span> elements marked</span>
+<span class="a">agent</span>  <span class="c">&rsaquo;</span> <span class="f">type_text</span>(<span class="m">3</span>, <span class="s">"ada@example.com"</span>)
+<span class="a">agent</span>  <span class="c">&rsaquo;</span> <span class="f">type_text</span>(<span class="m">4</span>, <span class="s">"&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;&bull;"</span>)
+<span class="a">agent</span>  <span class="c">&rsaquo;</span> <span class="f">click</span>(<span class="m">5</span>)
+       <span class="c">&lsaquo; <span class="s">&check;</span> clicked &lt;button&gt; "Sign in" &rarr; /dashboard &mdash; <span class="m">12</span> new elements</span>
+<span class="a">agent</span>  <span class="c">&rsaquo;</span> <span class="f">get_console_logs</span>()
+       <span class="c">&lsaquo; <span class="s">0 errors</span>, 2 warnings</span></pre>
+      </div>
     </div>
-    <div class="bc-proof-copy">
-      <h3>Tool output &mdash; in the model&rsquo;s context</h3>
-      <p>
-        Every <code>get_*</code>, <code>click</code>, <code>type_text</code>,
-        and <code>navigate</code> call returns this shape:
-        an image plus a short element map. The model sees pixels and reads
-        the list.
-      </p>
-      <ul class="bc-proof-legend">
-        <li><span class="bc-proof-num">1</span><span class="bc-proof-type">input</span><span>Search or jump to&hellip;</span></li>
-        <li><span class="bc-proof-num">2</span><span class="bc-proof-type">a</span><span>Pulls</span></li>
-        <li><span class="bc-proof-num">3</span><span class="bc-proof-type">a</span><span>Issues</span></li>
-        <li><span class="bc-proof-num">4</span><span class="bc-proof-type">a</span><span>Codespaces</span></li>
-        <li><span class="bc-proof-num">5</span><span class="bc-proof-type">button</span><span>Sign in</span></li>
-      </ul>
+  </section>
+  <!-- ===================================================================
+       FEATURES
+       =================================================================== -->
+  <section class="bc-section">
+    <div class="bc-wrap">
+      <div class="bc-head">
+        <p class="bc-eyebrow">Why it works</p>
+        <h2 class="bc-h2">Shaped around how agents fail, not how humans test.</h2>
+        <p class="bc-lede">Selector-driven automation assumes you already know the DOM. Agents don&rsquo;t — they guess, and they guess wrong. Every decision below exists to remove one of those guesses.</p>
+      </div>
+      <div class="bc-features">
+        <div class="bc-feature">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="7.5"/><path d="M12 1.5v3M12 19.5v3M1.5 12h3M19.5 12h3"/><circle cx="12" cy="12" r="2.2" fill="currentColor" stroke="none"/></svg></span>
+          <h3>Vision-first, selector-free</h3>
+          <p>Numbered red boxes over the live page. The agent names a number. There is no CSS selector to get wrong, no XPath to invent, no class name to hallucinate.</p>
+        </div>
+        <div class="bc-feature bc-feature--violet">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3 3 8l9 5 9-5-9-5Z"/><path d="m3 16 9 5 9-5"/><path d="m3 12 9 5 9-5"/></svg></span>
+          <h3>Shadow DOM &amp; iframe aware</h3>
+          <p>The element collector descends recursively into open shadow roots and same-origin iframes, compensating coordinate offsets as it goes. Component-framework apps just work.</p>
+        </div>
+        <div class="bc-feature bc-feature--teal">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M20.5 12a8.5 8.5 0 1 1-2.9-6.4"/><path d="M20.5 3.5v5h-5"/></svg></span>
+          <h3>Sessions that actually persist</h3>
+          <p>Chromium runs against a real profile directory via <code>launch_persistent_context</code>. Cookies, localStorage, and login state survive server restarts. Log in once, not once per run.</p>
+        </div>
+        <div class="bc-feature">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2.75" y="4" width="18.5" height="16" rx="2.5"/><path d="m7 9.5 3 2.5-3 2.5"/><path d="M13 15h4"/></svg></span>
+          <h3>DevTools in the same server</h3>
+          <p>Console logs, network requests with timing, uncaught JS errors, performance metrics, computed styles, cookies. Debugging a page needs no second MCP server.</p>
+        </div>
+        <div class="bc-feature bc-feature--violet">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2.5 4.5 5.6v5.2c0 4.6 3.1 8.1 7.5 9.7 4.4-1.6 7.5-5.1 7.5-9.7V5.6L12 2.5Z"/><path d="m8.8 11.8 2.3 2.3 4.1-4.4"/></svg></span>
+          <h3>Local, private, uncapped</h3>
+          <p>No cloud relay, no telemetry, no vendor rate limit. Screenshots are captured, annotated, and consumed on your machine — including the ones of your logged-in accounts.</p>
+        </div>
+        <div class="bc-feature bc-feature--teal">
+          <span class="bc-feature-icon" aria-hidden="true"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13.5 2 4.5 13.5h6l-1.2 8.5 9.2-12h-6L13.5 2Z"/></svg></span>
+          <h3>Zero marginal cost</h3>
+          <p>Everything runs on hardware you already pay for. A thousand clicks cost exactly the same as one: nothing. No per-action pricing, no surprise invoice.</p>
+        </div>
+      </div>
     </div>
-  </div>
-</div>
-
-<!-- ============================================================
-     CAPABILITY CARDS
-     ============================================================ -->
-<div class="bc-section">
-  <span class="bc-section-eyebrow">Why BrowserControl</span>
-  <h2 class="bc-section-title">Built for the agent loop. Not for humans.</h2>
-  <p class="bc-section-lede">
-    Every detail below exists because AI agents fail differently than
-    humans do. BrowserControl is shaped around their failure modes &mdash;
-    not around a human test runner.
-  </p>
-
-  <div class="bc-cap-grid">
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--red" aria-hidden="true">#</span>
-      <h3 class="bc-cap-title">Vision-first, selector-free</h3>
-      <p class="bc-cap-body">
-        Numbered red boxes. The agent picks a number. No CSS selectors, no
-        XPath, no hallucinated
-        <code>div.flex-container &gt; button.btn-primary:nth-child(3)</code>.
-      </p>
+  </section>
+  <!-- ===================================================================
+       COMPARISON
+       =================================================================== -->
+  <section class="bc-section bc-section--tint">
+    <div class="bc-wrap">
+      <div class="bc-head">
+        <p class="bc-eyebrow">How it compares</p>
+        <h2 class="bc-h2">Three ways to give an agent a browser.</h2>
+        <p class="bc-lede">Selector-based drivers are precise but blind. Hosted browser agents can see, but they meter every action and route your session through someone else&rsquo;s infrastructure.</p>
+      </div>
+      <div class="bc-compare-scroll">
+        <table class="bc-compare">
+          <thead>
+            <tr>
+              <th scope="col">&nbsp;</th>
+              <th scope="col" class="us">BrowserControl</th>
+              <th scope="col">Selector-driven MCP</th>
+              <th scope="col">Hosted browser agent</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <th scope="row">How the agent targets</th>
+              <td class="us">Numbered marks on a screenshot</td>
+              <td>CSS / XPath it has to guess</td>
+              <td>Natural language, resolved remotely</td>
+            </tr>
+            <tr>
+              <th scope="row">Sees the rendered page</th>
+              <td class="us">Yes, on every single call</td>
+              <td>No &mdash; text and DOM only</td>
+              <td>Yes</td>
+            </tr>
+            <tr>
+              <th scope="row">Where it runs</th>
+              <td class="us">Your machine</td>
+              <td>Your machine</td>
+              <td>Vendor cloud</td>
+            </tr>
+            <tr>
+              <th scope="row">Cost per 1,000 actions</th>
+              <td class="us">$0</td>
+              <td>$0</td>
+              <td>Metered per action</td>
+            </tr>
+            <tr>
+              <th scope="row">Logged-in sessions</th>
+              <td class="us">Persistent local profile</td>
+              <td>Usually per-run, ephemeral</td>
+              <td>Credentials leave your machine</td>
+            </tr>
+            <tr>
+              <th scope="row">Console &amp; network access</th>
+              <td class="us">Built in</td>
+              <td>Rarely</td>
+              <td>Rarely exposed</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
     </div>
-
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--violet" aria-hidden="true">{ }</span>
-      <h3 class="bc-cap-title">Shadow DOM &amp; iframe aware</h3>
-      <p class="bc-cap-body">
-        Recursively descends into open shadow roots and same-origin iframes
-        with coordinate-offset compensation. Modern web apps just work.
-      </p>
+  </section>
+  <!-- ===================================================================
+       QUICKSTART
+       =================================================================== -->
+  <section class="bc-section">
+    <div class="bc-wrap">
+      <div class="bc-head">
+        <p class="bc-eyebrow">Quickstart</p>
+        <h2 class="bc-h2">Installed and wired up in about a minute.</h2>
+        <p class="bc-lede">Chromium installs itself on first run, so there is no system browser binary to manage and nothing to keep in sync.</p>
+      </div>
+      <div class="bc-quick">
+        <div>
+          <ol class="bc-quick-steps">
+            <li>
+              <h3>Install the package</h3>
+              <p>Use whichever package manager you already have.</p>
+              <div class="bc-cmd"><span class="bc-prompt" aria-hidden="true">$</span>pip install browsercontrol</div>
+              <div class="bc-cmd"><span class="bc-prompt" aria-hidden="true">$</span>uv add browsercontrol</div>
+              <div class="bc-cmd"><span class="bc-prompt" aria-hidden="true">$</span>pipx install browsercontrol</div>
+            </li>
+            <li>
+              <h3>Point your client at it</h3>
+              <p>Drop the server block on the right into your MCP client config — Claude Desktop, Claude Code, Cursor, or anything else that speaks MCP.</p>
+            </li>
+            <li>
+              <h3>Ask for something visual</h3>
+              <p>&ldquo;Open my dashboard, screenshot it, and tell me which network requests failed.&rdquo; The first call boots Chromium and marks the page. See the <a href="getting-started/first-session/">first session walkthrough</a>.</p>
+            </li>
+          </ol>
+        </div>
+        <div>
+          <div class="bc-code-card">
+            <div class="bc-code-card-head"><span>claude_desktop_config.json</span><span class="badge">json</span></div>
+            <pre>{
+  <span class="k">"mcpServers"</span><span class="p">:</span> {
+    <span class="k">"browsercontrol"</span><span class="p">:</span> {
+      <span class="k">"command"</span><span class="p">:</span> <span class="v">"browsercontrol"</span>
+    }
+  }
+}</pre>
+          </div>
+          <p class="bc-quick-note">If Chromium ever fails to install itself, run <code>python -m playwright install chromium</code> once. Every configuration option is an environment variable — see <a href="configuration/">Configuration</a>.</p>
+        </div>
+      </div>
     </div>
-
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--mint" aria-hidden="true">&#8634;</span>
-      <h3 class="bc-cap-title">True persistent sessions</h3>
-      <p class="bc-cap-body">
-        Uses <code>launch_persistent_context</code>. Cookies, localStorage,
-        login state, and history all survive restarts. Log in once.
-      </p>
+  </section>
+  <!-- ===================================================================
+       DOC PATHS
+       =================================================================== -->
+  <section class="bc-section bc-section--tint">
+    <div class="bc-wrap">
+      <div class="bc-head bc-head--center">
+        <p class="bc-eyebrow">Documentation</p>
+        <h2 class="bc-h2">Where to go next.</h2>
+        <p class="bc-lede">Four entry points, depending on what you&rsquo;re trying to do right now.</p>
+      </div>
+      <div class="bc-docs-grid">
+        <a class="bc-doc-card" href="getting-started/">
+          <span class="bc-doc-kicker">Start here</span>
+          <h3>Getting started</h3>
+          <p>Install, connect your client, and run a first session end to end.</p>
+          <span class="bc-doc-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <a class="bc-doc-card" href="tools/">
+          <span class="bc-doc-kicker">Reference</span>
+          <h3>Tool reference</h3>
+          <p>All ~30 MCP tools with parameters and return shapes, by category.</p>
+          <span class="bc-doc-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <a class="bc-doc-card" href="guides/">
+          <span class="bc-doc-kicker">Recipes</span>
+          <h3>Guides</h3>
+          <p>Research, debugging, form filling, multi-tab work, recorded test runs.</p>
+          <span class="bc-doc-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+        <a class="bc-doc-card" href="concepts/">
+          <span class="bc-doc-kicker">Under the hood</span>
+          <h3>Concepts</h3>
+          <p>How marks are collected, why IDs are ephemeral, and the architecture.</p>
+          <span class="bc-doc-arrow" aria-hidden="true">&rarr;</span>
+        </a>
+      </div>
     </div>
-
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--red" aria-hidden="true">&#9881;</span>
-      <h3 class="bc-cap-title">Built-in devtools</h3>
-      <p class="bc-cap-body">
-        Console logs, network requests with timing, JS errors, page
-        performance, element inspection, computed styles. No second tool
-        needed.
-      </p>
+  </section>
+  <!-- ===================================================================
+       CLOSING CTA
+       =================================================================== -->
+  <section class="bc-cta">
+    <div class="bc-wrap bc-cta-inner">
+      <div>
+        <h2>Give your agent a browser that actually sees.</h2>
+        <p>One install, no cloud, no key. The shortest path from &ldquo;ask the model&rdquo; to watching the browser do the thing.</p>
+      </div>
+      <div class="bc-cta-row">
+        <a class="bc-btn bc-btn--primary" href="getting-started/installation/">
+          Install BrowserControl
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2.5 8h11M9 3.5 13.5 8 9 12.5"/></svg>
+        </a>
+        <a class="bc-btn bc-btn--ghost" href="https://github.com/adityasasidhar/browsercontrol" rel="noopener">
+          <svg viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27s1.36.09 2 .27c1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          Star on GitHub
+        </a>
+      </div>
     </div>
-
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--violet" aria-hidden="true">&#9737;</span>
-      <h3 class="bc-cap-title">100% local &amp; private</h3>
-      <p class="bc-cap-body">
-        No LLM API key. No cloud. No telemetry. No usage cap. Your browsing
-        stays on your machine &mdash; including the screenshots.
-      </p>
-    </div>
-
-    <div class="bc-cap">
-      <span class="bc-cap-icon bc-cap-icon--mint" aria-hidden="true">$0</span>
-      <h3 class="bc-cap-title">Zero marginal cost</h3>
-      <p class="bc-cap-body">
-        Runs on your hardware. <strong>$0 per 1,000 actions</strong> &mdash;
-        no API spend, no per-action fees, no surprise invoices at the end of
-        the month.
-      </p>
-    </div>
-  </div>
-</div>
-
-<!-- ============================================================
-     INSTALL BLOCK
-     ============================================================ -->
-<div class="bc-section">
-  <span class="bc-section-eyebrow">Install</span>
-  <h2 class="bc-section-title">Up and running in 30 seconds.</h2>
-  <p class="bc-section-lede">
-    Pick your installer. Chromium auto-installs on first run, so there is
-    no system-level browser binary to manage.
-  </p>
-
-<div class="bc-install">
-
-<h3>Install BrowserControl</h3>
-<p>Pick whichever package manager you already have. Chromium auto-installs on first run.</p>
-
-<div class="bc-install-tabs">
-  <div class="bc-install-tab">
-    <span class="bc-install-tab-label">pip</span>
-    <pre class="bc-install-cmd"><code>pip install browsercontrol</code></pre>
-  </div>
-  <div class="bc-install-tab">
-    <span class="bc-install-tab-label">uv</span>
-    <pre class="bc-install-cmd"><code>uv add browsercontrol</code></pre>
-  </div>
-  <div class="bc-install-tab">
-    <span class="bc-install-tab-label">pipx</span>
-    <pre class="bc-install-cmd"><code>pipx install browsercontrol</code></pre>
-  </div>
-</div>
-
-<div class="bc-install-note">
-  If Chromium fails to auto-install for any reason, run it once manually:
-  <code>python -m playwright install chromium</code>. That&rsquo;s it.
-</div>
-
-</div>
-</div>
-
-<!-- ============================================================
-     DOC PATH CARDS
-     ============================================================ -->
-<div class="bc-section">
-  <span class="bc-section-eyebrow">Documentation</span>
-  <h2 class="bc-section-title">Where to next.</h2>
-  <p class="bc-section-lede">
-    Pick the path that matches the moment you're in. Everything is organized
-    so the next click is obvious.
-  </p>
-
-  <div class="bc-doc-grid">
-    <a class="bc-doc" href="getting-started/index.md">
-      <span class="bc-doc-eyebrow">Start here</span>
-      <h3 class="bc-doc-title">Getting started</h3>
-      <p class="bc-doc-body">Install, connect, and run your first session in under five minutes.</p>
-      <span class="bc-doc-arrow">&rarr;</span>
-    </a>
-    <a class="bc-doc" href="tools/index.md">
-      <span class="bc-doc-eyebrow">Reference</span>
-      <h3 class="bc-doc-title">Tool reference</h3>
-      <p class="bc-doc-body">Every MCP tool, every parameter, organized by category.</p>
-      <span class="bc-doc-arrow">&rarr;</span>
-    </a>
-    <a class="bc-doc" href="guides/index.md">
-      <span class="bc-doc-eyebrow">Patterns</span>
-      <h3 class="bc-doc-title">Guides</h3>
-      <p class="bc-doc-body">Real-world recipes: research, debugging, recording, forms, multi-tab.</p>
-      <span class="bc-doc-arrow">&rarr;</span>
-    </a>
-    <a class="bc-doc" href="concepts/index.md">
-      <span class="bc-doc-eyebrow">Under the hood</span>
-      <h3 class="bc-doc-title">Concepts</h3>
-      <p class="bc-doc-body">How Set of Marks works, the action loop, and why it beats selectors.</p>
-      <span class="bc-doc-arrow">&rarr;</span>
-    </a>
-  </div>
-</div>
-
-<!-- ============================================================
-     FINAL CTA BAND
-     ============================================================ -->
-<div class="bc-final" aria-label="Install BrowserControl">
-  <div class="bc-final-copy">
-    <h3>Give your agent a browser that actually sees.</h3>
-    <p>
-      One install. Zero cloud. The shortest path from "ask the model" to
-      "watch the browser do the thing."
-    </p>
-  </div>
-  <div class="bc-final-cta">
-    <a href="getting-started/installation.md" class="md-button md-button--primary">
-      Install BrowserControl
-    </a>
-    <a href="https://github.com/adityasasidhar/browsercontrol"
-       class="md-button" rel="noopener">
-      Star on GitHub
-    </a>
-  </div>
-</div>
-
+  </section>
 </div>

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,935 +1,2202 @@
 /* =========================================================================
-   BrowserControl docs — design system
-   Palette: paper #FFF9F0 / ink #101820 / SoM red #EF3E3E / mint #8EDCC8 /
-            violet #7A63D2
+   BrowserControl — documentation design system
+   -------------------------------------------------------------------------
+   Built on MkDocs Material. Two layers:
+     1. a global brand layer that restyles every docs page, and
+     2. a landing-page layer (.bc-page) for the marketing surface.
+
+   Brand idea: Set of Marks. Numbered red boxes over a live page. The design
+   language borrows from that — hairline frames, mono element maps, and a
+   single loud red used only where the agent would "mark" something.
+
+   Specificity note: every landing-page rule is prefixed with `.bc-page` so
+   it outranks Material's `.md-typeset <tag>` rules, which would otherwise
+   reset the margins and sizes of the components below.
+   ========================================================================= */
+
+/* =========================================================================
+   1. TOKENS
    ========================================================================= */
 
 :root {
-  --bc-paper:        #FFF9F0;
-  --bc-paper-soft:   #F4EFE3;
-  --bc-paper-line:   #EAE3D2;
-  --bc-ink:          #101820;
-  --bc-ink-soft:     #2A2F38;
-  --bc-muted:        #6B6B6B;
-  --bc-red:          #EF3E3E;
-  --bc-red-soft:     #FFD9D2;
-  --bc-red-tint:     #FFF4F0;
-  --bc-mint:         #8EDCC8;
-  --bc-mint-deep:    #1F3A2E;
-  --bc-violet:       #7A63D2;
-  --bc-violet-soft:  #E8E2FA;
-  --bc-deep:         #101820;
-  --bc-deep-soft:    #1F2A38;
-  --bc-shadow:       0 1px 0 rgba(16, 24, 32, 0.06), 0 6px 18px rgba(16, 24, 32, 0.10);
-  --bc-shadow-soft:  0 1px 0 rgba(16, 24, 32, 0.04), 0 2px 6px rgba(16, 24, 32, 0.06);
-  --bc-radius:       10px;
-  --bc-radius-lg:    18px;
-  --bc-mono:         ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
-  --bc-sans:         -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  /* Surfaces — warm paper white, not beige */
+  --bc-bg: #fcfbf9;
+  --bc-bg-alt: #f6f4ef;
+  --bc-surface: #ffffff;
+  --bc-surface-2: #f7f5f1;
+  --bc-surface-3: #eceae3;
+
+  /* Lines */
+  --bc-line: #e6e2d9;
+  --bc-line-2: #d2ccbf;
+
+  /* Ink */
+  --bc-ink: #14181d;
+  --bc-ink-2: #3a424e;
+  --bc-ink-3: #5d6774;
+  --bc-muted: #7c8694;
+
+  /* Accents */
+  --bc-red: #ef3e3e;
+  --bc-red-ink: #c92a2a;
+  --bc-red-soft: #ffe9e5;
+  --bc-red-line: #ffcac3;
+  --bc-violet: #6c4fe0;
+  --bc-violet-soft: #ece7fd;
+  --bc-teal: #0e9f86;
+  --bc-teal-soft: #d9f4ec;
+  --bc-amber: #b45309;
+  --bc-amber-soft: #fdefd6;
+
+  /* Inverted panels */
+  --bc-deep: #0d1117;
+  --bc-deep-line: #262e3b;
+  --bc-deep-ink: #e8edf4;
+  --bc-deep-muted: #97a2b2;
+  --bc-deep-blue: #6ec3f7;
+
+  /* Elevation */
+  --bc-sh-1: 0 1px 2px rgba(20, 24, 29, 0.06);
+  --bc-sh-2: 0 1px 2px rgba(20, 24, 29, 0.05), 0 6px 16px -6px rgba(20, 24, 29, 0.14);
+  --bc-sh-3: 0 2px 4px rgba(20, 24, 29, 0.05), 0 18px 40px -14px rgba(20, 24, 29, 0.22);
+  --bc-glow: 0 0 0 1px rgba(239, 62, 62, 0.16), 0 12px 30px -12px rgba(239, 62, 62, 0.4);
+
+  /* Geometry */
+  --bc-r-sm: 8px;
+  --bc-r: 12px;
+  --bc-r-lg: 18px;
+
+  /* Type */
+  --bc-sans: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --bc-mono: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
+
+  /* Motion */
+  --bc-ease: cubic-bezier(0.32, 0.72, 0, 1);
+  --bc-fast: 140ms var(--bc-ease);
+
+  /* Rhythm */
+  --bc-gutter: clamp(1.15rem, 4vw, 2.5rem);
+  --bc-band: clamp(3.25rem, 7vw, 5.75rem);
+}
+
+[data-md-color-scheme="slate"] {
+  --bc-bg: #0b0f16;
+  --bc-bg-alt: #0f141d;
+  --bc-surface: #121824;
+  --bc-surface-2: #161e2b;
+  --bc-surface-3: #1e2836;
+
+  --bc-line: #222c3a;
+  --bc-line-2: #33404f;
+
+  --bc-ink: #eaeff6;
+  --bc-ink-2: #c3ccd9;
+  --bc-ink-3: #9aa5b5;
+  --bc-muted: #7d8798;
+
+  --bc-red: #ff5f5f;
+  --bc-red-ink: #ff8078;
+  --bc-red-soft: #35181a;
+  --bc-red-line: #5a2422;
+  --bc-violet: #a78bfa;
+  --bc-violet-soft: #241f3d;
+  --bc-teal: #3ddbb8;
+  --bc-teal-soft: #0f2b28;
+  --bc-amber: #fbbf24;
+  --bc-amber-soft: #2c2211;
+
+  --bc-deep: #070a10;
+  --bc-deep-line: #1e2735;
+  --bc-deep-ink: #e8edf4;
+  --bc-deep-muted: #8b95a6;
+  --bc-deep-blue: #7dd3fc;
+
+  --bc-sh-1: 0 1px 2px rgba(0, 0, 0, 0.4);
+  --bc-sh-2: 0 1px 2px rgba(0, 0, 0, 0.4), 0 8px 20px -8px rgba(0, 0, 0, 0.7);
+  --bc-sh-3: 0 2px 6px rgba(0, 0, 0, 0.45), 0 24px 48px -18px rgba(0, 0, 0, 0.85);
+  --bc-glow: 0 0 0 1px rgba(255, 95, 95, 0.25), 0 14px 36px -14px rgba(255, 95, 95, 0.45);
+}
+
+/* =========================================================================
+   2. MATERIAL BRIDGE — brand tokens drive the stock theme
+   ========================================================================= */
+
+[data-md-color-scheme="default"],
+[data-md-color-scheme="slate"] {
+  --md-default-bg-color: var(--bc-bg);
+  --md-default-fg-color: var(--bc-ink);
+  --md-default-fg-color--light: var(--bc-ink-3);
+  --md-default-fg-color--lighter: var(--bc-muted);
+  --md-typeset-color: var(--bc-ink-2);
+  --md-typeset-a-color: var(--bc-red-ink);
+  --md-accent-fg-color: var(--bc-red);
+  --md-code-bg-color: var(--bc-surface-2);
+  --md-code-fg-color: var(--bc-ink);
+  /* The header and tabs strip read as part of the page, not as a black slab.
+     Driving Material's own primary pair is more reliable than overriding
+     `.md-header`, which the `primary: black` palette targets at higher
+     specificity. */
+  --md-primary-fg-color: var(--bc-bg);
+  --md-primary-bg-color: var(--bc-ink);
+  --md-primary-bg-color--light: var(--bc-muted);
+}
+
+html {
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body,
+.md-typeset {
+  font-feature-settings: "cv11", "ss01";
+}
+
+.md-typeset {
+  font-size: 0.79rem;
+  line-height: 1.72;
+}
+
+/* A little more room for the wide tool-reference tables */
+.md-grid {
+  max-width: 68rem;
 }
 
 /* -------------------------------------------------------------------------
-   Landing-page layout overrides
-   Material's flex parent collapses `.md-content` to 0 width when both
-   sidebars are hidden, which collapses our landing-page grid. Force full
-   width only when the landing page is detected, so the rest of the docs
-   keep the standard Material layout.
+   2a. Announcement bar
    ------------------------------------------------------------------------- */
-.md-content:has(> .md-content__inner .bc-page) {
+
+.md-banner {
+  background: var(--bc-deep);
+  color: var(--bc-deep-ink);
+  border-bottom: 1px solid var(--bc-deep-line);
+}
+
+.md-banner__inner {
+  margin: 0.45rem auto;
+  font-size: 0.66rem;
+}
+
+.bc-announce {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: center;
+  gap: 0.55rem;
+  font-family: var(--bc-sans);
+}
+
+.bc-announce-tag {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.1rem 0.45rem;
+  border-radius: 999px;
+  background: var(--bc-red);
+  color: #fff;
+  font-size: 0.58rem;
+  font-weight: 700;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+}
+
+.bc-announce-text {
+  color: var(--bc-deep-muted);
+}
+
+.bc-announce-link {
+  color: #fff !important;
+  font-weight: 600;
+  text-decoration: none !important;
+  white-space: nowrap;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.35);
+}
+
+.bc-announce-link:hover {
+  border-bottom-color: var(--bc-red);
+}
+
+/* -------------------------------------------------------------------------
+   2b. Header + navigation tabs
+   ------------------------------------------------------------------------- */
+
+.md-header,
+[data-md-color-primary="black"] .md-header {
+  background-color: color-mix(in srgb, var(--bc-bg) 86%, transparent);
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  backdrop-filter: saturate(180%) blur(14px);
+  color: var(--bc-ink);
+  box-shadow: none;
+  border-bottom: 1px solid var(--bc-line);
+}
+
+.md-header--shadow {
+  box-shadow: var(--bc-sh-1);
+}
+
+.md-header__title {
+  font-weight: 650;
+  letter-spacing: -0.012em;
+}
+
+.md-header__topic:first-child {
+  font-weight: 650;
+}
+
+.md-header__button.md-logo :is(img, svg) {
+  width: 1.3rem;
+  height: 1.3rem;
+}
+
+.md-search__form {
+  background: var(--bc-surface-2);
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r-sm);
+  box-shadow: none;
+  transition: border-color var(--bc-fast), background var(--bc-fast);
+}
+
+.md-search__form:hover {
+  background: var(--bc-surface-2);
+  border-color: var(--bc-line-2);
+}
+
+[data-md-toggle="search"]:checked ~ .md-header .md-search__form {
+  border-color: var(--bc-red);
+  background: var(--bc-surface);
+}
+
+.md-search__input {
+  color: var(--bc-ink);
+  font-size: 0.72rem;
+}
+
+.md-search__input::placeholder {
+  color: var(--bc-muted);
+}
+
+.md-search__icon,
+.md-search__options .md-icon {
+  color: var(--bc-muted);
+}
+
+.md-search-result__meta {
+  background: var(--bc-surface-2);
+  color: var(--bc-muted);
+}
+
+.md-search-result__article--document .md-search-result__title {
+  font-weight: 650;
+}
+
+.md-search-result__link:focus,
+.md-search-result__link:hover {
+  background: var(--bc-red-soft);
+}
+
+/* Tabs strip reads as a toolbar rather than a black slab */
+.md-tabs,
+[data-md-color-primary="black"] .md-tabs {
+  background-color: transparent;
+  color: var(--bc-ink-3);
+  border-bottom: 1px solid var(--bc-line);
+  overflow: visible;
+}
+
+.md-tabs__list {
+  gap: 0.15rem;
+}
+
+.md-tabs__item {
+  padding: 0;
+  height: auto;
+}
+
+.md-tabs__link {
+  margin: 0.42rem 0;
+  padding: 0.25rem 0.6rem;
+  border-radius: var(--bc-r-sm);
+  font-size: 0.7rem;
+  font-weight: 550;
+  opacity: 1;
+  color: var(--bc-ink-3);
+  transition: background var(--bc-fast), color var(--bc-fast);
+}
+
+.md-tabs__link:hover {
+  color: var(--bc-ink);
+  background: var(--bc-surface-2);
+}
+
+.md-tabs__link--active,
+.md-tabs__item--active .md-tabs__link {
+  color: var(--bc-ink);
+  font-weight: 650;
+  background: var(--bc-surface-2);
+  box-shadow: inset 0 0 0 1px var(--bc-line);
+}
+
+/* -------------------------------------------------------------------------
+   2c. Sidebars
+   ------------------------------------------------------------------------- */
+
+.md-nav {
+  font-size: 0.71rem;
+}
+
+.md-nav__title {
+  font-size: 0.62rem;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--bc-muted);
+  padding-bottom: 0.4rem;
+}
+
+.md-sidebar--primary .md-nav__item > .md-nav__link {
+  border-radius: 6px;
+  padding: 0.18rem 0.5rem;
+  margin: 0.06rem 0;
+  color: var(--bc-ink-3);
+  transition: background var(--bc-fast), color var(--bc-fast);
+}
+
+.md-sidebar--primary .md-nav__link:hover {
+  background: var(--bc-surface-2);
+  color: var(--bc-ink);
+}
+
+.md-nav__link--active,
+.md-nav__item .md-nav__link--active {
+  color: var(--bc-ink);
+  font-weight: 650;
+}
+
+.md-sidebar--primary .md-nav__link--active {
+  background: var(--bc-red-soft);
+  box-shadow: inset 2px 0 0 var(--bc-red);
+}
+
+.md-nav--secondary .md-nav__link {
+  color: var(--bc-muted);
+  border-left: 2px solid transparent;
+  padding-left: 0.55rem;
+  transition: color var(--bc-fast), border-color var(--bc-fast);
+}
+
+.md-nav--secondary .md-nav__link:hover {
+  color: var(--bc-ink);
+}
+
+.md-nav--secondary .md-nav__link--active {
+  color: var(--bc-ink);
+  border-left-color: var(--bc-red);
+}
+
+.md-sidebar__scrollwrap::-webkit-scrollbar-thumb {
+  background: var(--bc-line-2);
+  border-radius: 999px;
+}
+
+/* -------------------------------------------------------------------------
+   2d. Typeset — headings, rules, links
+   ------------------------------------------------------------------------- */
+
+.md-typeset h1 {
+  font-family: var(--bc-sans);
+  font-size: 1.72rem;
+  line-height: 1.15;
+  font-weight: 700;
+  letter-spacing: -0.028em;
+  color: var(--bc-ink);
+  margin: 0 0 0.45rem;
+}
+
+.md-typeset h1 + p {
+  font-size: 0.88rem;
+  line-height: 1.65;
+  color: var(--bc-ink-3);
+}
+
+.md-typeset h2 {
+  font-family: var(--bc-sans);
+  font-size: 1.18rem;
+  font-weight: 680;
+  letter-spacing: -0.022em;
+  color: var(--bc-ink);
+  margin: 2.4rem 0 0.7rem;
+  padding-top: 1.1rem;
+  border-top: 1px solid var(--bc-line);
+}
+
+.md-typeset h3 {
+  font-family: var(--bc-sans);
+  font-size: 1rem;
+  font-weight: 650;
+  letter-spacing: -0.014em;
+  color: var(--bc-ink);
+  margin: 1.7rem 0 0.5rem;
+}
+
+.md-typeset :is(h4, h5, h6) {
+  font-family: var(--bc-sans);
+  font-weight: 650;
+  color: var(--bc-ink);
+  letter-spacing: -0.008em;
+  text-transform: none;
+}
+
+.md-typeset hr {
+  border-bottom: 1px solid var(--bc-line);
+  margin: 2rem 0;
+}
+
+.md-typeset a {
+  text-decoration-thickness: 1px;
+  text-underline-offset: 2px;
+  transition: color var(--bc-fast);
+}
+
+.md-typeset a:hover {
+  color: var(--bc-red);
+}
+
+.md-typeset strong {
+  color: var(--bc-ink);
+  font-weight: 650;
+}
+
+.md-typeset blockquote {
+  border-left: 2px solid var(--bc-red);
+  color: var(--bc-ink-3);
+  background: var(--bc-surface-2);
+  border-radius: 0 var(--bc-r-sm) var(--bc-r-sm) 0;
+  padding: 0.35rem 0.9rem;
+}
+
+.md-typeset .headerlink {
+  color: var(--bc-line-2);
+  transition: color var(--bc-fast);
+}
+
+.md-typeset :hover > .headerlink {
+  color: var(--bc-red);
+}
+
+/* -------------------------------------------------------------------------
+   2e. Code
+   ------------------------------------------------------------------------- */
+
+.md-typeset code {
+  background: var(--bc-surface-2);
+  border: 1px solid var(--bc-line);
+  border-radius: 5px;
+  padding: 0.08em 0.36em;
+  font-size: 0.82em;
+  color: var(--bc-ink);
+  word-break: normal;
+}
+
+.md-typeset a code {
+  color: inherit;
+  border-color: var(--bc-red-line);
+}
+
+.md-typeset pre > code {
+  border: 0;
+  padding: 0.72rem 0.9rem;
+  font-size: 0.72rem;
+  line-height: 1.65;
+}
+
+.md-typeset .highlight,
+.md-typeset .highlighttable {
+  border-radius: var(--bc-r);
+  border: 1px solid var(--bc-line);
+  overflow: hidden;
+  background: var(--bc-surface-2);
+  box-shadow: var(--bc-sh-1);
+}
+
+.md-typeset .highlight > pre,
+.md-typeset pre {
+  margin: 0;
+}
+
+.md-typeset .highlight + .result {
+  border: 1px solid var(--bc-line);
+  border-top: 0;
+  border-radius: 0 0 var(--bc-r) var(--bc-r);
+}
+
+.md-clipboard {
+  color: var(--bc-muted);
+}
+
+.md-clipboard:hover {
+  color: var(--bc-red);
+}
+
+/* Tabbed content (pymdownx.tabbed) */
+.md-typeset .tabbed-labels {
+  box-shadow: 0 -1px 0 var(--bc-line) inset;
+  gap: 0.1rem;
+}
+
+.md-typeset .tabbed-labels > label {
+  font-size: 0.68rem;
+  font-weight: 600;
+  color: var(--bc-muted);
+  padding: 0.5rem 0.7rem;
+  transition: color var(--bc-fast);
+}
+
+.md-typeset .tabbed-labels > label:hover {
+  color: var(--bc-ink);
+}
+
+.md-typeset .tabbed-set > input:checked + label {
+  color: var(--bc-ink);
+  border-color: var(--bc-red);
+}
+
+/* -------------------------------------------------------------------------
+   2f. Tables
+   ------------------------------------------------------------------------- */
+
+/* Let tables use the full measure instead of shrink-wrapping their content */
+.md-typeset__table {
+  display: block;
+  width: 100%;
+}
+
+.md-typeset table:not([class]) {
+  display: table;
+  width: 100%;
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r);
+  box-shadow: none;
+  font-size: 0.71rem;
+  overflow: hidden;
+}
+
+.md-typeset table:not([class]) th {
+  background: var(--bc-surface-2);
+  color: var(--bc-ink);
+  font-weight: 650;
+  font-size: 0.66rem;
+  letter-spacing: 0.045em;
+  text-transform: uppercase;
+  border-bottom: 1px solid var(--bc-line);
+  padding: 0.6rem 0.8rem;
+  white-space: nowrap;
+}
+
+.md-typeset table:not([class]) td {
+  border-top: 1px solid var(--bc-line);
+  padding: 0.6rem 0.8rem;
+  vertical-align: top;
+}
+
+.md-typeset table:not([class]) tbody tr {
+  transition: background var(--bc-fast);
+}
+
+.md-typeset table:not([class]) tbody tr:hover {
+  background: var(--bc-surface-2);
+}
+
+.md-typeset table:not([class]) td code {
+  white-space: nowrap;
+}
+
+/* -------------------------------------------------------------------------
+   2g. Admonitions
+   ------------------------------------------------------------------------- */
+
+.md-typeset .admonition,
+.md-typeset details {
+  border: 1px solid var(--bc-line);
+  border-left: 3px solid var(--bc-line-2);
+  border-radius: var(--bc-r);
+  box-shadow: none;
+  background: var(--bc-surface);
+  font-size: 0.73rem;
+}
+
+.md-typeset .admonition-title,
+.md-typeset summary {
+  background: var(--bc-surface-2);
+  font-weight: 650;
+  font-size: 0.73rem;
+  padding: 0.5rem 0.75rem 0.5rem 2.1rem;
+}
+
+.md-typeset .admonition-title::before,
+.md-typeset summary::before {
+  top: 0.55rem;
+  left: 0.7rem;
+}
+
+.md-typeset .admonition > :last-child,
+.md-typeset details > :last-child {
+  margin-bottom: 0.65rem;
+}
+
+/* Material colours each variant with `.admonition.<type>`, so the accent
+   rules below need one more class to win. `:is()` supplies it. */
+.md-typeset :is(.admonition, details):is(.note, .abstract, .summary, .tldr, .info, .todo, .quote, .cite) {
+  border-color: var(--bc-line);
+  border-left-color: var(--bc-violet);
+}
+
+.md-typeset :is(.note, .abstract, .summary, .tldr, .info, .todo, .quote, .cite) > :is(.admonition-title, summary) {
+  background: var(--bc-violet-soft);
+}
+
+.md-typeset :is(.admonition, details):is(.tip, .hint, .important, .success, .check, .done, .example) {
+  border-color: var(--bc-line);
+  border-left-color: var(--bc-teal);
+}
+
+.md-typeset :is(.tip, .hint, .important, .success, .check, .done, .example) > :is(.admonition-title, summary) {
+  background: var(--bc-teal-soft);
+}
+
+.md-typeset :is(.admonition, details):is(.warning, .caution, .attention, .question, .help, .faq) {
+  border-color: var(--bc-line);
+  border-left-color: var(--bc-amber);
+}
+
+.md-typeset :is(.warning, .caution, .attention, .question, .help, .faq) > :is(.admonition-title, summary) {
+  background: var(--bc-amber-soft);
+}
+
+.md-typeset :is(.admonition, details):is(.danger, .error, .failure, .fail, .missing, .bug) {
+  border-color: var(--bc-line);
+  border-left-color: var(--bc-red);
+}
+
+.md-typeset :is(.danger, .error, .failure, .fail, .missing, .bug) > :is(.admonition-title, summary) {
+  background: var(--bc-red-soft);
+}
+
+/* -------------------------------------------------------------------------
+   2h. Grid cards + buttons
+   ------------------------------------------------------------------------- */
+
+/* Slightly narrower minimum so category card sets land three-up */
+.md-typeset .grid {
+  grid-template-columns: repeat(auto-fit, minmax(min(100%, 11.5rem), 1fr));
+  gap: 0.7rem;
+}
+
+.md-typeset .grid.cards > ul > li,
+.md-typeset .grid > .card {
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r);
+  background: var(--bc-surface);
+  box-shadow: none;
+  padding: 0.9rem 1rem;
+  transition: border-color var(--bc-fast), box-shadow var(--bc-fast),
+    transform var(--bc-fast);
+}
+
+.md-typeset .grid.cards > ul > li:hover {
+  border-color: var(--bc-line-2);
+  box-shadow: var(--bc-sh-2);
+  transform: translateY(-2px);
+}
+
+.md-typeset .grid.cards > ul > li > hr {
+  margin: 0.6rem 0;
+  border-color: var(--bc-line);
+}
+
+.md-typeset .grid.cards .lg.middle {
+  color: var(--bc-red);
+}
+
+.md-typeset .md-button {
+  border-radius: var(--bc-r-sm);
+  border-width: 1px;
+  border-color: var(--bc-line-2);
+  color: var(--bc-ink);
+  font-size: 0.72rem;
+  font-weight: 600;
+  padding: 0.42rem 0.9rem;
+  transition: background var(--bc-fast), color var(--bc-fast),
+    border-color var(--bc-fast), transform var(--bc-fast);
+}
+
+.md-typeset .md-button:hover {
+  background: var(--bc-ink);
+  border-color: var(--bc-ink);
+  color: var(--bc-bg);
+  transform: translateY(-1px);
+}
+
+.md-typeset .md-button--primary {
+  background: var(--bc-red);
+  border-color: var(--bc-red);
+  color: #fff;
+}
+
+.md-typeset .md-button--primary:hover {
+  background: var(--bc-ink);
+  border-color: var(--bc-ink);
+  color: var(--bc-bg);
+}
+
+/* -------------------------------------------------------------------------
+   2i. Footer
+   ------------------------------------------------------------------------- */
+
+.md-footer,
+.md-footer-meta {
+  background: var(--bc-deep);
+}
+
+.md-footer-meta {
+  border-top: 1px solid var(--bc-deep-line);
+}
+
+.md-footer__link {
+  border-radius: var(--bc-r);
+  transition: background var(--bc-fast);
+}
+
+.md-footer__link:hover {
+  background: rgba(255, 255, 255, 0.05);
+  opacity: 1;
+}
+
+.md-footer__title {
+  font-weight: 600;
+}
+
+.md-copyright,
+.md-footer-meta .md-social__link {
+  color: var(--bc-deep-muted);
+}
+
+.md-social__link:hover {
+  color: #fff;
+}
+
+.md-content__button {
+  color: var(--bc-muted);
+}
+
+.md-content__button:hover {
+  color: var(--bc-red);
+}
+
+/* =========================================================================
+   3. LANDING PAGE
+   ========================================================================= */
+
+/* The landing page is full-bleed. Material caps `.md-main__inner` at 61rem
+   and collapses `.md-content` to zero width when both sidebars are hidden,
+   so both need releasing — but only on this page. */
+.md-main__inner:has(.bc-page) {
+  max-width: none;
+  margin: 0;
+}
+
+.md-content:has(.bc-page) {
   width: 100%;
   max-width: 100%;
 }
 
-.md-content:has(> .md-content__inner .bc-page) > .md-content__inner {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0 1.5rem 1.5rem;
-}
-
-[data-md-color-scheme="slate"] {
-  --bc-paper:        #0F1620;
-  --bc-paper-soft:   #1A2330;
-  --bc-paper-line:   #2A3543;
-  --bc-ink:          #F4EFE3;
-  --bc-ink-soft:     #D4CDB9;
-  --bc-muted:        #98A2B3;
-  --bc-red:          #EF3E3E;
-  --bc-red-soft:     #5A1F1A;
-  --bc-red-tint:     #2A1A1A;
-  --bc-mint:         #8EDCC8;
-  --bc-mint-deep:    #1F3A2E;
-  --bc-violet:       #A692EE;
-  --bc-violet-soft:  #2A2548;
-  --bc-deep:         #050B12;
-  --bc-deep-soft:    #111B2A;
-  --bc-shadow:       0 1px 0 rgba(0, 0, 0, 0.30), 0 8px 24px rgba(0, 0, 0, 0.45);
-  --bc-shadow-soft:  0 1px 0 rgba(0, 0, 0, 0.25), 0 2px 8px rgba(0, 0, 0, 0.30);
-}
-
-/* -------------------------------------------------------------------------
-   Base typography overrides for landing-page content.
-   These apply to top-level headings in the bc-page and do not cascade into
-   nested blocks (install, install-note, proof, etc.) which style their own
-   headings explicitly.
-   ------------------------------------------------------------------------- */
-.bc-page > h1,
-.bc-page > h2,
-.bc-page > h3,
-.bc-hero-headline,
-.bc-section-title,
-.bc-cap-title,
-.bc-doc-title,
-.bc-step-title {
-  color: var(--bc-ink);
-  letter-spacing: -0.01em;
-}
-
-.bc-hero-headline,
-.bc-section-title {
-  font-weight: 800;
-}
-
-.bc-page a:not(.md-button):not(.bc-badge):not(.bc-doc):not(.bc-cap) {
-  color: var(--bc-ink);
-  text-decoration: underline;
-  text-decoration-color: var(--bc-red);
-  text-underline-offset: 3px;
-  text-decoration-thickness: 2px;
-}
-
-.bc-page a:not(.md-button):not(.bc-badge):not(.bc-doc):not(.bc-cap):hover {
-  text-decoration-color: var(--bc-violet);
-}
-
-/* -------------------------------------------------------------------------
-   Page frame
-   ------------------------------------------------------------------------- */
-.bc-page {
-  background: var(--bc-paper);
-}
-
-.md-main .md-content .bc-page {
-  background: var(--bc-paper);
-}
-
-.bc-eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.25rem 0.7rem;
-  background: var(--bc-deep);
-  color: #FFF9F0;
-  border-radius: 999px;
-  font-family: var(--bc-sans);
-  font-weight: 700;
-  font-size: 0.72rem;
-  letter-spacing: 0.10em;
-  text-transform: uppercase;
-}
-
-.bc-eyebrow .bc-eyebrow-dot {
-  width: 8px;
-  height: 8px;
-  background: var(--bc-red);
-  border-radius: 999px;
-  display: inline-block;
-}
-
-/* -------------------------------------------------------------------------
-   HERO
-   ------------------------------------------------------------------------- */
-.bc-hero {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
-  gap: 2.5rem;
-  align-items: center;
-  padding: 2.75rem 0 2.5rem;
-  border-bottom: 1.5px solid var(--bc-ink);
-}
-
-.bc-hero::before {
-  content: "";
-  position: absolute;
-  top: -1.5rem;
-  left: 0;
-  right: 0;
-  height: 6px;
-  background: var(--bc-mint);
-  border-radius: 3px;
-}
-
-.bc-hero-headline {
-  margin: 0.85rem 0 0.75rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: clamp(2.1rem, 5.6vw, 3.6rem);
-  line-height: 1.05;
-  color: var(--bc-ink);
-  letter-spacing: -0.02em;
-}
-
-.bc-hero-headline .bc-mark-red {
-  color: var(--bc-red);
-  white-space: nowrap;
-}
-
-.bc-hero-lede {
-  margin: 0 0 1.5rem;
-  font-size: 1.08rem;
-  line-height: 1.55;
-  color: var(--bc-ink-soft);
-  max-width: 36em;
-}
-
-.bc-hero-cta {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.6rem;
-  margin: 0 0 1.5rem;
-}
-
-.bc-hero-cta .md-button {
+.md-content:has(.bc-page) > .md-content__inner {
+  max-width: none;
   margin: 0;
-  border-radius: var(--bc-radius);
-  font-weight: 700;
-  border-width: 1.5px;
+  padding: 0;
 }
 
-.bc-hero-cta .md-button--primary {
-  background: var(--bc-red);
-  border-color: var(--bc-red);
-  color: #FFFFFF;
+.md-content:has(.bc-page) > .md-content__inner::before,
+.md-content:has(.bc-page) .md-content__button {
+  display: none;
 }
 
-.bc-hero-cta .md-button--primary:hover {
-  background: var(--bc-ink);
-  border-color: var(--bc-ink);
-  color: var(--bc-paper);
+/* Neutralise Material's typeset defaults inside the landing page. `:where()`
+   keeps this at .md-typeset + .bc-page specificity so the `.bc-page …`
+   component rules below always win. */
+.md-typeset .bc-page
+  :where(h1, h2, h3, h4, p, ul, ol, li, pre, code, table, figure, blockquote) {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: none;
+  list-style: none;
+  font-size: inherit;
+  line-height: inherit;
+  color: inherit;
 }
 
-.bc-hero-cta .md-button:not(.md-button--primary) {
-  background: var(--bc-paper);
-  border-color: var(--bc-ink);
+.bc-page {
+  font-family: var(--bc-sans);
+  color: var(--bc-ink-2);
+  font-size: 0.8rem;
+  line-height: 1.6;
+}
+
+.bc-page :is(h1, h2, h3, h4) {
+  font-family: var(--bc-sans);
   color: var(--bc-ink);
 }
 
-.bc-hero-cta .md-button:not(.md-button--primary):hover {
-  background: var(--bc-ink);
-  color: var(--bc-paper);
+.bc-page .bc-wrap {
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 var(--bc-gutter);
 }
 
-.bc-trust-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  font-family: var(--bc-sans);
-  font-size: 0.85rem;
-  color: var(--bc-ink-soft);
+.bc-page .bc-section {
+  padding: var(--bc-band) 0;
+  border-top: 1px solid var(--bc-line);
 }
 
-.bc-trust-row > span {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.3rem 0.65rem;
-  background: var(--bc-paper-soft);
-  border: 1px solid var(--bc-paper-line);
-  border-radius: 999px;
-}
-
-.bc-trust-row svg {
-  width: 14px;
-  height: 14px;
-  color: var(--bc-mint);
-}
-
-.bc-hero-visual {
-  position: relative;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.bc-hero-visual .bc-demo {
-  width: 100%;
-  height: auto;
-  max-width: 720px;
-  border-radius: var(--bc-radius-lg);
-  box-shadow: var(--bc-shadow);
-  background: var(--bc-paper);
-}
-
-.bc-hero-mascot {
-  position: absolute;
-  bottom: -22px;
-  right: -10px;
-  width: 96px;
-  height: 96px;
-  background: var(--bc-paper);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: 14px;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  box-shadow: var(--bc-shadow-soft);
-}
-
-@media screen and (min-width: 60em) {
-  .bc-hero-mascot {
-    display: flex;
-  }
-}
-
-.bc-hero-mascot img {
-  width: 78px;
-  height: 78px;
-}
-
-/* Hero responsive collapse */
-@media screen and (max-width: 60em) {
-  .bc-hero {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.5rem;
-    padding: 2rem 0 1.5rem;
-  }
-  .bc-hero-mascot {
-    display: none;
-  }
-  .bc-hero-visual {
-    margin-top: 0.5rem;
-  }
-}
-
-@media screen and (max-width: 30em) {
-  .bc-hero-cta .md-button {
-    width: 100%;
-    text-align: center;
-  }
-  .bc-hero-headline {
-    font-size: clamp(1.9rem, 9vw, 2.4rem);
-  }
+.bc-page .bc-section--tint {
+  background: var(--bc-bg-alt);
 }
 
 /* -------------------------------------------------------------------------
-   BADGE STRIP
+   3a. Shared section header
    ------------------------------------------------------------------------- */
-.bc-badge-strip {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  padding: 1.25rem 0;
-  border-bottom: 1px solid var(--bc-paper-line);
+
+.bc-page .bc-head {
+  max-width: 44rem;
+  margin: 0 0 clamp(1.75rem, 4vw, 2.75rem);
 }
 
-.bc-badge {
+.bc-page .bc-head--center {
+  margin-left: auto;
+  margin-right: auto;
+  text-align: center;
+}
+
+.bc-page .bc-eyebrow {
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
-  padding: 0.35rem 0.75rem;
-  border-radius: 999px;
-  font-family: var(--bc-sans);
-  font-size: 0.78rem;
-  font-weight: 600;
-  line-height: 1;
-  border: 1.5px solid var(--bc-ink);
-  color: var(--bc-ink);
-  background: var(--bc-paper);
-  text-decoration: none;
-  transition: transform 0.12s ease, background 0.12s ease, color 0.12s ease;
+  font-size: 0.66rem;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--bc-red-ink);
+  margin: 0 0 0.7rem;
 }
 
-.bc-badge:hover {
-  background: var(--bc-ink);
-  color: var(--bc-paper);
+.bc-page .bc-eyebrow::before {
+  content: "";
+  width: 14px;
+  height: 2px;
+  border-radius: 2px;
+  background: var(--bc-red);
+}
+
+.bc-page .bc-head--center .bc-eyebrow {
+  justify-content: center;
+}
+
+.bc-page .bc-h2 {
+  margin: 0 0 0.6rem;
+  font-size: clamp(1.3rem, 2.6vw, 1.8rem);
+  line-height: 1.14;
+  font-weight: 720;
+  letter-spacing: -0.032em;
+  text-wrap: balance;
+}
+
+.bc-page .bc-lede {
+  margin: 0;
+  font-size: clamp(0.85rem, 1.4vw, 0.95rem);
+  line-height: 1.68;
+  color: var(--bc-ink-3);
+}
+
+.bc-page .bc-lede code {
+  font-family: var(--bc-mono);
+  font-size: 0.88em;
+  background: var(--bc-surface-2);
+  border: 1px solid var(--bc-line);
+  border-radius: 4px;
+  padding: 0.05em 0.3em;
+  color: var(--bc-ink);
+}
+
+/* -------------------------------------------------------------------------
+   3b. Hero
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-hero {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2.25rem, 5.5vw, 4.5rem) 0 clamp(2.25rem, 5.5vw, 3.75rem);
+  isolation: isolate;
+}
+
+/* Faint measurement grid + red bloom, echoing the SoM overlay */
+.bc-page .bc-hero::before {
+  content: "";
+  position: absolute;
+  inset: -40% -10% auto -10%;
+  height: 160%;
+  z-index: -2;
+  background-image: linear-gradient(
+      to right,
+      color-mix(in srgb, var(--bc-line) 75%, transparent) 1px,
+      transparent 1px
+    ),
+    linear-gradient(
+      to bottom,
+      color-mix(in srgb, var(--bc-line) 75%, transparent) 1px,
+      transparent 1px
+    );
+  background-size: 46px 46px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 68% 52% at 50% 44%,
+    #000 0%,
+    transparent 78%
+  );
+  mask-image: radial-gradient(
+    ellipse 68% 52% at 50% 44%,
+    #000 0%,
+    transparent 78%
+  );
+}
+
+.bc-page .bc-hero::after {
+  content: "";
+  position: absolute;
+  z-index: -1;
+  top: -20rem;
+  right: -12rem;
+  width: 44rem;
+  height: 44rem;
+  border-radius: 50%;
+  background: radial-gradient(
+    circle,
+    color-mix(in srgb, var(--bc-red) 15%, transparent) 0%,
+    transparent 62%
+  );
+  pointer-events: none;
+}
+
+.bc-page .bc-hero-inner {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.04fr);
+  gap: clamp(2rem, 5vw, 3.25rem);
+  align-items: center;
+}
+
+.bc-page .bc-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  padding: 0.26rem 0.7rem 0.26rem 0.35rem;
+  border: 1px solid var(--bc-line);
+  background: var(--bc-surface);
+  border-radius: 999px;
+  font-size: 0.66rem;
+  font-weight: 600;
+  color: var(--bc-ink-2);
+  text-decoration: none !important;
+  box-shadow: var(--bc-sh-1);
+  transition: border-color var(--bc-fast), transform var(--bc-fast);
+}
+
+.bc-page .bc-pill:hover {
+  border-color: var(--bc-line-2);
   transform: translateY(-1px);
 }
 
-.bc-badge .bc-badge-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 999px;
-  background: var(--bc-mint);
-  flex-shrink: 0;
-}
-
-.bc-badge--red .bc-badge-dot     { background: var(--bc-red); }
-.bc-badge--violet .bc-badge-dot  { background: var(--bc-violet); }
-.bc-badge--ink .bc-badge-dot     { background: var(--bc-ink); }
-
-/* -------------------------------------------------------------------------
-   SECTION HEADINGS
-   ------------------------------------------------------------------------- */
-.bc-section {
-  padding: 3rem 0 0.5rem;
-}
-
-.bc-section + .bc-section {
-  border-top: 1px solid var(--bc-paper-line);
-}
-
-.bc-section-eyebrow {
-  display: inline-block;
-  font-family: var(--bc-sans);
-  font-weight: 700;
-  font-size: 0.72rem;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--bc-red);
-  margin: 0 0 0.6rem;
-}
-
-.bc-section-title {
-  margin: 0 0 0.75rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: clamp(1.6rem, 3.4vw, 2.25rem);
-  line-height: 1.15;
-  color: var(--bc-ink);
-  letter-spacing: -0.01em;
-}
-
-.bc-section-lede {
-  margin: 0 0 1.75rem;
-  max-width: 56ch;
-  font-size: 1.02rem;
-  color: var(--bc-ink-soft);
-  line-height: 1.55;
-}
-
-/* -------------------------------------------------------------------------
-   THREE-STEP SoM EXPLANATION
-   ------------------------------------------------------------------------- */
-.bc-steps {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 0.5rem;
-}
-
-.bc-step {
-  position: relative;
-  background: var(--bc-paper);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: var(--bc-radius-lg);
-  padding: 1.25rem 1.25rem 1.1rem;
-}
-
-.bc-step-num {
+.bc-page .bc-pill-tag {
   display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 30px;
-  height: 30px;
+  padding: 0.1rem 0.42rem;
   border-radius: 999px;
   background: var(--bc-red);
-  color: #FFFFFF;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 0.95rem;
-  margin-bottom: 0.75rem;
-}
-
-.bc-step-title {
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 1.1rem;
-  margin: 0 0 0.4rem;
-  color: var(--bc-ink);
-}
-
-.bc-step-body {
-  margin: 0;
-  color: var(--bc-ink-soft);
-  font-size: 0.95rem;
-  line-height: 1.5;
-}
-
-.bc-step-arrow {
-  position: absolute;
-  top: 50%;
-  right: -14px;
-  transform: translateY(-50%);
-  z-index: 1;
-  width: 28px;
-  height: 28px;
-  background: var(--bc-paper);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: 999px;
-  display: none;
-  align-items: center;
-  justify-content: center;
-  color: var(--bc-ink);
-  font-weight: 800;
-}
-
-.bc-step:last-child .bc-step-arrow {
-  display: none;
-}
-
-@media screen and (min-width: 60em) {
-  .bc-step:not(:last-child) .bc-step-arrow {
-    display: flex;
-  }
-}
-
-@media screen and (max-width: 50em) {
-  .bc-steps {
-    grid-template-columns: minmax(0, 1fr);
-  }
-  .bc-step-arrow {
-    display: none !important;
-  }
-}
-
-/* -------------------------------------------------------------------------
-   PROOF PANEL — full-width annotated screenshot
-   ------------------------------------------------------------------------- */
-.bc-proof {
-  position: relative;
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.05fr);
-  gap: 1.75rem;
-  align-items: center;
-  margin: 1.5rem 0 0;
-  padding: 1.75rem;
-  background: var(--bc-paper-soft);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: var(--bc-radius-lg);
-}
-
-.bc-proof-copy h3 {
-  margin: 0 0 0.6rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: clamp(1.25rem, 2.4vw, 1.65rem);
-  color: var(--bc-ink);
-}
-
-.bc-proof-copy p {
-  margin: 0 0 1rem;
-  color: var(--bc-ink-soft);
-  line-height: 1.55;
-}
-
-.bc-proof-legend {
-  margin: 0;
-  padding: 0;
-  list-style: none;
-}
-
-.bc-proof-legend li {
-  display: grid;
-  grid-template-columns: 28px 64px 1fr;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.45rem 0;
-  border-bottom: 1px dashed var(--bc-paper-line);
-  font-family: var(--bc-mono);
-  font-size: 0.85rem;
-  color: var(--bc-ink);
-}
-
-.bc-proof-legend li:last-child {
-  border-bottom: 0;
-}
-
-.bc-proof-legend .bc-proof-num {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  width: 22px;
-  height: 22px;
-  border-radius: 999px;
-  background: var(--bc-red);
-  color: #FFFFFF;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 0.78rem;
-}
-
-.bc-proof-legend .bc-proof-type {
-  color: var(--bc-violet);
-  font-weight: 700;
-}
-
-.bc-proof-img img,
-.bc-proof-img svg {
-  width: 100%;
-  height: auto;
-  border-radius: var(--bc-radius);
-  border: 1.5px solid var(--bc-ink);
-  background: var(--bc-paper);
-  box-shadow: var(--bc-shadow);
-  display: block;
-}
-
-@media screen and (max-width: 60em) {
-  .bc-proof {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 1.25rem;
-    padding: 1.25rem;
-  }
-}
-
-/* -------------------------------------------------------------------------
-   CAPABILITY CARDS
-   ------------------------------------------------------------------------- */
-.bc-cap-grid {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 0;
-}
-
-@media screen and (max-width: 60em) {
-  .bc-cap-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media screen and (max-width: 36em) {
-  .bc-cap-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-.bc-cap {
-  position: relative;
-  background: var(--bc-paper);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: var(--bc-radius-lg);
-  padding: 1.25rem 1.25rem 1.1rem;
-  transition: transform 0.12s ease, box-shadow 0.12s ease;
-}
-
-.bc-cap:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--bc-shadow);
-}
-
-.bc-cap-icon {
-  width: 36px;
-  height: 36px;
-  border-radius: 10px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  margin-bottom: 0.7rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 1.05rem;
-}
-
-.bc-cap-icon--red    { background: var(--bc-red-soft);  color: var(--bc-red); }
-.bc-cap-icon--mint   { background: var(--bc-mint-deep); color: var(--bc-mint); }
-.bc-cap-icon--violet { background: var(--bc-violet-soft); color: var(--bc-violet); }
-
-.bc-cap-title {
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 1.05rem;
-  margin: 0 0 0.4rem;
-  color: var(--bc-ink);
-}
-
-.bc-cap-body {
-  margin: 0;
-  color: var(--bc-ink-soft);
-  font-size: 0.94rem;
-  line-height: 1.5;
-}
-
-/* -------------------------------------------------------------------------
-   INSTALL BLOCK
-   ------------------------------------------------------------------------- */
-.bc-install {
-  margin: 1.5rem 0 0;
-  padding: 1.5rem;
-  background: var(--bc-deep);
-  color: #FFF9F0;
-  border-radius: var(--bc-radius-lg);
-  border: 1.5px solid var(--bc-deep);
-  box-shadow: var(--bc-shadow);
-}
-
-.bc-install h3 {
-  margin: 0 0 0.5rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 1.25rem;
-  color: #FFF9F0;
-}
-
-.bc-install > p {
-  margin: 0 0 1.1rem;
-  color: #FFF9F0;
-  opacity: 0.85;
-  font-size: 0.95rem;
-}
-
-.bc-install-tabs {
-  display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-  gap: 0.6rem;
-  margin: 0 0 0.4rem;
-}
-
-@media screen and (max-width: 50em) {
-  .bc-install-tabs {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-.bc-install-tab {
-  background: var(--bc-deep-soft);
-  border: 1px solid #2F3741;
-  border-radius: 10px;
-  padding: 0.7rem 0.85rem 0.85rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-}
-
-.bc-install-tab-label {
-  font-family: var(--bc-mono);
-  font-size: 0.7rem;
+  color: #fff;
+  font-size: 0.58rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  color: #8EDCC8;
 }
 
-.bc-install-cmd {
-  margin: 0;
-  padding: 0;
-  font-family: var(--bc-mono);
-  font-size: 0.88rem;
-  line-height: 1.4;
-  color: #FFF9F0;
-  background: transparent;
-  white-space: nowrap;
-  overflow-x: auto;
+.bc-page .bc-pill-arrow {
+  color: var(--bc-muted);
+  font-weight: 700;
 }
 
-.bc-install-cmd .md-code__nav,
-.bc-install-cmd .md-code__button {
-  display: none !important;
+.bc-page .bc-h1 {
+  margin: 1.05rem 0 0.9rem;
+  font-size: clamp(2rem, 4.3vw, 2.8rem);
+  line-height: 1.04;
+  font-weight: 760;
+  letter-spacing: -0.042em;
+  text-wrap: balance;
 }
 
-.bc-install-cmd code {
-  background: transparent;
-  color: inherit;
-  padding: 0;
-  font-size: inherit;
-  font-family: inherit;
-}
-
-.bc-install-note {
-  margin: 0.85rem 0 0;
-  padding: 0.65rem 0.9rem;
-  background: #1F3A2E;
-  color: var(--bc-mint);
-  border-radius: 8px;
-  font-size: 0.9rem;
-}
-
-.bc-install-note code {
-  background: rgba(255, 255, 255, 0.08);
-  color: #FFF9F0;
-  padding: 0.05rem 0.4rem;
-  border-radius: 4px;
-  font-size: 0.85em;
-}
-
-/* -------------------------------------------------------------------------
-   DOC PATH CARDS
-   ------------------------------------------------------------------------- */
-.bc-doc-grid {
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 1rem;
-  margin: 1.5rem 0 0;
-}
-
-@media screen and (max-width: 70em) {
-  .bc-doc-grid {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-  }
-}
-
-@media screen and (max-width: 36em) {
-  .bc-doc-grid {
-    grid-template-columns: minmax(0, 1fr);
-  }
-}
-
-.bc-doc {
-  display: block;
-  padding: 1.1rem 1.1rem 1rem;
-  background: var(--bc-paper);
-  border: 1.5px solid var(--bc-ink);
-  border-radius: var(--bc-radius-lg);
-  text-decoration: none;
-  color: var(--bc-ink);
-  transition: background 0.12s ease, color 0.12s ease, transform 0.12s ease;
-}
-
-.bc-doc:hover {
-  background: var(--bc-ink);
-  color: var(--bc-paper);
-  transform: translateY(-2px);
-}
-
-.bc-doc:hover .bc-doc-arrow {
-  color: var(--bc-paper);
-}
-
-.bc-doc-eyebrow {
+/* The word the agent would "mark" */
+.bc-page .bc-h1 .bc-marked {
+  position: relative;
   display: inline-block;
-  font-family: var(--bc-sans);
-  font-weight: 700;
-  font-size: 0.7rem;
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
   color: var(--bc-red);
-  margin-bottom: 0.4rem;
+  padding: 0 0.06em;
 }
 
-.bc-doc:hover .bc-doc-eyebrow {
-  color: var(--bc-mint);
+.bc-page .bc-h1 .bc-marked::before {
+  content: "";
+  position: absolute;
+  inset: -0.08em -0.02em -0.06em;
+  border: 2px solid var(--bc-red);
+  border-radius: 5px;
+  opacity: 0.55;
 }
 
-.bc-doc-title {
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: 1.05rem;
-  margin: 0 0 0.3rem;
-}
-
-.bc-doc-body {
-  font-size: 0.88rem;
-  color: var(--bc-ink-soft);
-  line-height: 1.45;
-  margin: 0 0 0.6rem;
-}
-
-.bc-doc:hover .bc-doc-body {
-  color: var(--bc-paper);
-  opacity: 0.85;
-}
-
-.bc-doc-arrow {
-  font-family: var(--bc-mono);
-  color: var(--bc-red);
-  font-weight: 700;
-}
-
-/* -------------------------------------------------------------------------
-   FINAL CTA BAND
-   ------------------------------------------------------------------------- */
-.bc-final {
-  margin-top: 3rem;
-  padding: 2.25rem 1.75rem;
-  background: var(--bc-deep);
-  color: #FFF9F0;
-  border-radius: var(--bc-radius-lg);
-  display: grid;
-  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
-  gap: 1.5rem;
+.bc-page .bc-h1 .bc-marked::after {
+  content: "1";
+  position: absolute;
+  top: -0.66em;
+  left: -0.18em;
+  display: flex;
   align-items: center;
-  border: 1.5px solid var(--bc-deep);
+  justify-content: center;
+  width: 1.15em;
+  height: 1.15em;
+  font-size: 0.3em;
+  font-weight: 700;
+  font-family: var(--bc-mono);
+  color: #fff;
+  background: var(--bc-red);
+  border-radius: 4px;
 }
 
-.bc-final h3 {
-  margin: 0 0 0.5rem;
-  font-family: var(--bc-sans);
-  font-weight: 800;
-  font-size: clamp(1.4rem, 2.8vw, 1.9rem);
-  color: #FFF9F0;
+.bc-page .bc-hero-lede {
+  margin: 0 0 1.4rem;
+  max-width: 32rem;
+  font-size: clamp(0.9rem, 1.5vw, 1rem);
+  line-height: 1.62;
+  color: var(--bc-ink-3);
 }
 
-.bc-final p {
-  margin: 0;
-  color: #FFF9F0;
-  opacity: 0.85;
-  line-height: 1.5;
+.bc-page .bc-hero-lede strong {
+  color: var(--bc-ink);
+  font-weight: 620;
 }
 
-.bc-final-cta {
+.bc-page .bc-cta-row {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.6rem;
-  justify-content: flex-end;
+  gap: 0.55rem;
+  margin: 0 0 1.25rem;
 }
 
-.bc-final-cta .md-button {
-  margin: 0;
-  border-radius: var(--bc-radius);
-  font-weight: 700;
-  border-width: 1.5px;
+.bc-page .bc-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.6rem 1.1rem;
+  border-radius: var(--bc-r-sm);
+  border: 1px solid transparent;
+  font-size: 0.79rem;
+  font-weight: 620;
+  line-height: 1.2;
+  text-decoration: none !important;
+  transition: background var(--bc-fast), color var(--bc-fast),
+    border-color var(--bc-fast), transform var(--bc-fast),
+    box-shadow var(--bc-fast);
 }
 
-.bc-final-cta .md-button--primary {
+.bc-page .bc-btn svg {
+  width: 15px;
+  height: 15px;
+  flex-shrink: 0;
+}
+
+.bc-page .bc-btn--primary {
   background: var(--bc-red);
   border-color: var(--bc-red);
-  color: #FFFFFF;
+  color: #fff !important;
+  box-shadow: 0 6px 18px -8px rgba(239, 62, 62, 0.7);
 }
 
-.bc-final-cta .md-button--primary:hover {
-  background: #FFF9F0;
-  border-color: #FFF9F0;
-  color: var(--bc-deep);
+.bc-page .bc-btn--primary:hover {
+  background: var(--bc-ink);
+  border-color: var(--bc-ink);
+  color: var(--bc-bg) !important;
+  transform: translateY(-1px);
+  box-shadow: var(--bc-sh-2);
 }
 
-.bc-final-cta .md-button:not(.md-button--primary) {
-  background: var(--bc-deep);
-  border-color: #FFF9F0;
-  color: #FFF9F0;
+.bc-page .bc-btn--ghost {
+  background: var(--bc-surface);
+  border-color: var(--bc-line-2);
+  color: var(--bc-ink) !important;
 }
 
-.bc-final-cta .md-button:not(.md-button--primary):hover {
-  background: #FFF9F0;
-  color: var(--bc-deep);
+.bc-page .bc-btn--ghost:hover {
+  border-color: var(--bc-ink);
+  transform: translateY(-1px);
+  box-shadow: var(--bc-sh-2);
 }
 
-@media screen and (max-width: 60em) {
-  .bc-final {
-    grid-template-columns: minmax(0, 1fr);
-    padding: 1.75rem 1.25rem;
-  }
-  .bc-final-cta {
-    justify-content: flex-start;
-  }
+/* One-liner install */
+.bc-page .bc-hero-cmd {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.45rem 0.8rem;
+  border: 1px dashed var(--bc-line-2);
+  border-radius: var(--bc-r-sm);
+  background: var(--bc-surface-2);
+  font-family: var(--bc-mono);
+  font-size: 0.73rem;
+  color: var(--bc-ink);
 }
 
-@media screen and (max-width: 30em) {
-  .bc-final-cta .md-button {
-    width: 100%;
-    text-align: center;
-  }
+.bc-page .bc-prompt {
+  color: var(--bc-red);
+  font-weight: 700;
+  user-select: none;
+}
+
+.bc-page .bc-hero-cmd code {
+  font-family: var(--bc-mono);
+  font-size: 1em;
+  color: inherit;
+}
+
+.bc-page .bc-trust {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem 1.1rem;
+  margin: 1.25rem 0 0;
+  font-size: 0.72rem;
+  color: var(--bc-muted);
+}
+
+.bc-page .bc-trust li {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin: 0;
+}
+
+.bc-page .bc-trust svg {
+  width: 13px;
+  height: 13px;
+  color: var(--bc-teal);
+  flex-shrink: 0;
 }
 
 /* -------------------------------------------------------------------------
-   Reduced motion
+   3c. The Set-of-Marks "scope" — hero visual, built in HTML so it follows
+        the active colour scheme instead of shipping a baked screenshot.
    ------------------------------------------------------------------------- */
-@media (prefers-reduced-motion: reduce) {
-  .bc-cap,
-  .bc-doc,
-  .bc-badge {
-    transition: none;
+
+.bc-page .bc-scope {
+  display: grid;
+  gap: 0.7rem;
+}
+
+.bc-page .bc-window {
+  border: 1px solid var(--bc-line-2);
+  border-radius: var(--bc-r-lg);
+  background: var(--bc-surface);
+  box-shadow: var(--bc-sh-3);
+  overflow: hidden;
+}
+
+.bc-page .bc-window-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.6rem;
+  background: var(--bc-surface-2);
+  border-bottom: 1px solid var(--bc-line);
+}
+
+.bc-page .bc-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: 999px;
+  background: var(--bc-line-2);
+  flex-shrink: 0;
+}
+
+.bc-page .bc-dot:first-child {
+  background: var(--bc-red);
+}
+
+.bc-page .bc-window-url {
+  flex: 1;
+  margin-left: 0.25rem;
+  padding: 0.14rem 0.5rem;
+  border-radius: 999px;
+  background: var(--bc-bg);
+  border: 1px solid var(--bc-line);
+  font-family: var(--bc-mono);
+  font-size: 0.58rem;
+  color: var(--bc-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.bc-page .bc-window-tag {
+  padding: 0.1rem 0.38rem;
+  border-radius: 4px;
+  background: var(--bc-red);
+  color: #fff;
+  font-family: var(--bc-mono);
+  font-size: 0.54rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+}
+
+/* Stylised page under the marks. Everything is positioned in percent inside
+   a fixed-ratio box so the marks stay registered at any width. */
+.bc-page .bc-viewport {
+  position: relative;
+  aspect-ratio: 8 / 5;
+  background: var(--bc-bg);
+}
+
+.bc-page .bc-viewport > * {
+  position: absolute;
+}
+
+.bc-page .bc-sk {
+  background: var(--bc-surface-3);
+  border-radius: 3px;
+}
+
+.bc-page .bc-sk--round {
+  border-radius: 999px;
+}
+
+.bc-page .bc-sk--field {
+  background: var(--bc-surface);
+  border: 1px solid var(--bc-line);
+  border-radius: 5px;
+}
+
+.bc-page .bc-sk--btn {
+  background: var(--bc-ink);
+  border-radius: 5px;
+}
+
+.bc-page .bc-sk--strong {
+  background: var(--bc-line-2);
+}
+
+.bc-page .bc-topbar {
+  inset: 0 0 auto 0;
+  height: 13%;
+  background: var(--bc-surface);
+  border-bottom: 1px solid var(--bc-line);
+}
+
+.bc-page .bc-panel {
+  left: 24%;
+  top: 24%;
+  width: 52%;
+  height: 62%;
+  background: var(--bc-surface);
+  border: 1px solid var(--bc-line);
+  border-radius: 10px;
+  box-shadow: var(--bc-sh-1);
+}
+
+.bc-page .bc-mark {
+  left: var(--x);
+  top: var(--y);
+  width: var(--w);
+  height: var(--h);
+  border: 2px solid var(--bc-red);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--bc-red) 7%, transparent);
+  animation: bc-mark-in 420ms var(--bc-ease) both;
+  animation-delay: calc(var(--i) * 110ms + 200ms);
+}
+
+.bc-page .bc-mark::before {
+  content: attr(data-n);
+  position: absolute;
+  top: -9px;
+  left: -3px;
+  min-width: 15px;
+  height: 15px;
+  padding: 0 3px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 3px;
+  background: var(--bc-red);
+  color: #fff;
+  font-family: var(--bc-mono);
+  font-size: 9px;
+  font-weight: 700;
+  line-height: 1;
+}
+
+@keyframes bc-mark-in {
+  from {
+    opacity: 0;
+    transform: scale(1.15);
   }
-  .bc-cap:hover,
-  .bc-doc:hover,
-  .bc-badge:hover {
+  to {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+/* Element map beside the window */
+.bc-page .bc-map {
+  border: 1px solid var(--bc-line-2);
+  border-radius: var(--bc-r-lg);
+  background: var(--bc-deep);
+  color: var(--bc-deep-ink);
+  box-shadow: var(--bc-sh-3);
+  overflow: hidden;
+  font-family: var(--bc-mono);
+  font-size: 0.62rem;
+}
+
+.bc-page .bc-map-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.4rem;
+  padding: 0.45rem 0.65rem;
+  border-bottom: 1px solid var(--bc-deep-line);
+  color: var(--bc-deep-muted);
+  font-size: 0.58rem;
+  letter-spacing: 0.02em;
+}
+
+.bc-page .bc-map-head b {
+  color: var(--bc-deep-ink);
+  font-weight: 600;
+  text-transform: none;
+  letter-spacing: 0;
+}
+
+.bc-page .bc-map-list {
+  margin: 0;
+  padding: 0.35rem 0;
+}
+
+.bc-page .bc-map-list li {
+  display: grid;
+  grid-template-columns: 1rem 4rem minmax(0, 1fr);
+  align-items: baseline;
+  gap: 0.35rem;
+  margin: 0;
+  padding: 0.18rem 0.6rem;
+  animation: bc-row-in 320ms var(--bc-ease) both;
+  animation-delay: calc(var(--i) * 110ms + 260ms);
+}
+
+.bc-page .bc-map-list .n {
+  color: var(--bc-red);
+  font-weight: 700;
+}
+
+.bc-page .bc-map-list .t {
+  color: var(--bc-violet);
+}
+
+.bc-page .bc-map-list .l {
+  color: var(--bc-deep-muted);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@keyframes bc-row-in {
+  from {
+    opacity: 0;
+    transform: translateX(-4px);
+  }
+  to {
+    opacity: 1;
     transform: none;
   }
 }
 
+.bc-page .bc-map-call {
+  border-top: 1px solid var(--bc-deep-line);
+  padding: 0.5rem 0.6rem;
+  background: rgba(255, 255, 255, 0.02);
+  line-height: 1.8;
+}
+
+.bc-page .bc-map-call .arrow {
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-map-call .fn {
+  color: var(--bc-deep-ink);
+  font-weight: 600;
+}
+
+.bc-page .bc-map-call .ok {
+  color: var(--bc-teal);
+}
+
 /* -------------------------------------------------------------------------
-   Skip-link and accessibility helpers
+   3d. Stat strip
    ------------------------------------------------------------------------- */
-.bc-visually-hidden {
+
+/* Full-bleed band, but the cells line up with the wrap above it */
+.bc-page .bc-stats {
+  border-top: 1px solid var(--bc-line);
+  border-bottom: 1px solid var(--bc-line);
+  background: var(--bc-surface);
+}
+
+.bc-page .bc-stats-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.bc-page .bc-stat {
+  padding: 1.2rem 1.35rem;
+  border-left: 1px solid var(--bc-line);
+}
+
+.bc-page .bc-stat:first-child {
+  border-left: 0;
+  padding-left: 0;
+}
+
+.bc-page .bc-stat:last-child {
+  padding-right: 0;
+}
+
+.bc-page .bc-stat-num {
+  display: block;
+  font-size: clamp(1.15rem, 2.2vw, 1.5rem);
+  font-weight: 720;
+  letter-spacing: -0.03em;
+  color: var(--bc-ink);
+  line-height: 1.1;
+}
+
+.bc-page .bc-stat-num em {
+  font-style: normal;
+  color: var(--bc-red);
+}
+
+.bc-page .bc-stat-label {
+  display: block;
+  margin-top: 0.2rem;
+  font-size: 0.7rem;
+  color: var(--bc-muted);
+  line-height: 1.45;
+}
+
+/* -------------------------------------------------------------------------
+   3e. The loop — three steps + transcript
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-steps {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.bc-page .bc-step {
+  position: relative;
+  padding: 1.15rem 1.15rem 1.25rem;
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r);
+  background: var(--bc-surface);
+  transition: border-color var(--bc-fast), box-shadow var(--bc-fast),
+    transform var(--bc-fast);
+}
+
+.bc-page .bc-step:hover {
+  border-color: var(--bc-line-2);
+  box-shadow: var(--bc-sh-2);
+  transform: translateY(-2px);
+}
+
+.bc-page .bc-step-n {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 26px;
+  border-radius: 6px;
+  background: var(--bc-red);
+  color: #fff;
+  font-family: var(--bc-mono);
+  font-size: 0.74rem;
+  font-weight: 700;
+  margin-bottom: 0.7rem;
+}
+
+.bc-page .bc-step h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.94rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+
+.bc-page .bc-step p {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.6;
+  color: var(--bc-ink-3);
+}
+
+.bc-page .bc-step code,
+.bc-page .bc-feature code {
+  font-family: var(--bc-mono);
+  font-size: 0.9em;
+  background: var(--bc-surface-2);
+  border: 1px solid var(--bc-line);
+  border-radius: 4px;
+  padding: 0.04em 0.3em;
+  color: var(--bc-ink);
+  word-break: break-word;
+}
+
+/* Connector between steps */
+.bc-page .bc-step::after {
+  content: "";
+  position: absolute;
+  top: 2.05rem;
+  right: -0.55rem;
+  width: 0.5rem;
+  height: 1px;
+  background: var(--bc-line-2);
+}
+
+.bc-page .bc-step:last-child::after {
+  display: none;
+}
+
+.bc-page .bc-transcript {
+  margin-top: 1.25rem;
+  border: 1px solid var(--bc-deep-line);
+  border-radius: var(--bc-r-lg);
+  background: var(--bc-deep);
+  box-shadow: var(--bc-sh-3);
+  overflow: hidden;
+}
+
+.bc-page .bc-transcript-head {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid var(--bc-deep-line);
+  font-family: var(--bc-mono);
+  font-size: 0.58rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-transcript-head .bc-dot {
+  background: #39434f;
+}
+
+.bc-page .bc-transcript-head .bc-dot:first-child {
+  background: var(--bc-red);
+}
+
+.bc-page .bc-transcript-head .sp {
+  margin-left: 0.3rem;
+}
+
+.bc-page .bc-transcript-body {
+  margin: 0;
+  padding: 0.85rem 1rem 1rem;
+  overflow-x: auto;
+  font-family: var(--bc-mono);
+  font-size: 0.69rem;
+  line-height: 1.85;
+  color: var(--bc-deep-ink);
+  white-space: pre;
+}
+
+.bc-page .bc-transcript-body .c {
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-transcript-body .a {
+  color: var(--bc-violet);
+  font-weight: 600;
+}
+
+.bc-page .bc-transcript-body .f {
+  color: var(--bc-deep-blue);
+}
+
+.bc-page .bc-transcript-body .s {
+  color: var(--bc-teal);
+}
+
+.bc-page .bc-transcript-body .m {
+  color: var(--bc-red);
+  font-weight: 600;
+}
+
+/* -------------------------------------------------------------------------
+   3f. Feature grid
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-features {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1px;
+  background: var(--bc-line);
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r-lg);
+  overflow: hidden;
+}
+
+.bc-page .bc-feature {
+  position: relative;
+  padding: 1.45rem 1.35rem 1.55rem;
+  background: var(--bc-surface);
+  transition: background var(--bc-fast);
+}
+
+.bc-page .bc-feature:hover {
+  background: var(--bc-surface-2);
+}
+
+.bc-page .bc-feature-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 34px;
+  height: 34px;
+  margin-bottom: 0.8rem;
+  border-radius: 9px;
+  background: var(--bc-red-soft);
+  color: var(--bc-red-ink);
+  border: 1px solid var(--bc-red-line);
+}
+
+.bc-page .bc-feature-icon svg {
+  width: 17px;
+  height: 17px;
+}
+
+.bc-page .bc-feature--violet .bc-feature-icon {
+  background: var(--bc-violet-soft);
+  color: var(--bc-violet);
+  border-color: color-mix(in srgb, var(--bc-violet) 32%, transparent);
+}
+
+.bc-page .bc-feature--teal .bc-feature-icon {
+  background: var(--bc-teal-soft);
+  color: var(--bc-teal);
+  border-color: color-mix(in srgb, var(--bc-teal) 32%, transparent);
+}
+
+.bc-page .bc-feature h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.92rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+
+.bc-page .bc-feature p {
+  margin: 0;
+  font-size: 0.78rem;
+  line-height: 1.62;
+  color: var(--bc-ink-3);
+}
+
+/* -------------------------------------------------------------------------
+   3g. Comparison table
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-compare-scroll {
+  overflow-x: auto;
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r-lg);
+  background: var(--bc-surface);
+}
+
+.bc-page .bc-compare {
+  width: 100%;
+  min-width: 34rem;
+  border-collapse: collapse;
+  font-size: 0.76rem;
+}
+
+.bc-page .bc-compare :is(th, td) {
+  padding: 0.68rem 0.9rem;
+  text-align: left;
+  border-bottom: 1px solid var(--bc-line);
+  vertical-align: top;
+}
+
+.bc-page .bc-compare thead th {
+  background: var(--bc-surface-2);
+  font-size: 0.67rem;
+  font-weight: 650;
+  letter-spacing: 0.04em;
+  color: var(--bc-muted);
+  white-space: nowrap;
+}
+
+.bc-page .bc-compare thead th.us {
+  color: var(--bc-ink);
+  background: var(--bc-red-soft);
+}
+
+.bc-page .bc-compare tbody th {
+  font-weight: 550;
+  color: var(--bc-ink-2);
+  white-space: nowrap;
+}
+
+.bc-page .bc-compare td.us {
+  background: color-mix(in srgb, var(--bc-red-soft) 50%, transparent);
+  color: var(--bc-ink);
+  font-weight: 550;
+}
+
+.bc-page .bc-compare tr:last-child :is(th, td) {
+  border-bottom: 0;
+}
+
+/* -------------------------------------------------------------------------
+   3h. Quickstart — install steps + MCP config
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-quick {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.1fr);
+  gap: 1.5rem;
+  align-items: start;
+}
+
+.bc-page .bc-quick-steps {
+  margin: 0 0 0 0.75rem;
+  padding: 0;
+  counter-reset: bc-q;
+}
+
+.bc-page .bc-quick-steps > li {
+  position: relative;
+  counter-increment: bc-q;
+  margin: 0;
+  padding: 0 0 1.35rem 2.1rem;
+  border-left: 1px dashed var(--bc-line-2);
+}
+
+.bc-page .bc-quick-steps > li:last-child {
+  border-left-color: transparent;
+  padding-bottom: 0;
+}
+
+.bc-page .bc-quick-steps > li::before {
+  content: counter(bc-q);
+  position: absolute;
+  left: -0.78rem;
+  top: -0.15rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.55rem;
+  height: 1.55rem;
+  border-radius: 999px;
+  background: var(--bc-surface);
+  border: 1px solid var(--bc-line-2);
+  color: var(--bc-ink);
+  font-family: var(--bc-mono);
+  font-size: 0.69rem;
+  font-weight: 700;
+}
+
+.bc-page .bc-quick-steps h3 {
+  margin: 0.1rem 0 0.25rem;
+  font-size: 0.89rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.35;
+}
+
+.bc-page .bc-quick-steps p {
+  margin: 0 0 0.5rem;
+  font-size: 0.77rem;
+  line-height: 1.6;
+  color: var(--bc-ink-3);
+}
+
+.bc-page .bc-quick-steps p:last-child {
+  margin-bottom: 0;
+}
+
+.bc-page .bc-quick-steps a {
+  color: var(--bc-red-ink);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.bc-page .bc-cmd {
+  display: block;
+  padding: 0.5rem 0.7rem;
+  border-radius: var(--bc-r-sm);
+  border: 1px solid var(--bc-line);
+  background: var(--bc-surface-2);
+  font-family: var(--bc-mono);
+  font-size: 0.72rem;
+  color: var(--bc-ink);
+  overflow-x: auto;
+  white-space: nowrap;
+}
+
+.bc-page .bc-cmd .bc-prompt {
+  margin-right: 0.45rem;
+}
+
+.bc-page .bc-cmd + .bc-cmd {
+  margin-top: 0.3rem;
+}
+
+.bc-page .bc-code-card {
+  border: 1px solid var(--bc-deep-line);
+  border-radius: var(--bc-r-lg);
+  background: var(--bc-deep);
+  box-shadow: var(--bc-sh-3);
+  overflow: hidden;
+}
+
+.bc-page .bc-code-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  padding: 0.5rem 0.85rem;
+  border-bottom: 1px solid var(--bc-deep-line);
+  font-family: var(--bc-mono);
+  font-size: 0.6rem;
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-code-card-head .badge {
+  padding: 0.08rem 0.4rem;
+  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.07);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.bc-page .bc-code-card pre {
+  margin: 0;
+  padding: 0.85rem 1rem 1rem;
+  overflow-x: auto;
+  font-family: var(--bc-mono);
+  font-size: 0.7rem;
+  line-height: 1.75;
+  color: var(--bc-deep-ink);
+  white-space: pre;
+}
+
+.bc-page .bc-code-card .k {
+  color: var(--bc-deep-blue);
+}
+
+.bc-page .bc-code-card .v {
+  color: var(--bc-teal);
+}
+
+.bc-page .bc-code-card .p {
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-quick-note {
+  margin-top: 0.7rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: var(--bc-r-sm);
+  border: 1px solid var(--bc-line);
+  background: var(--bc-surface-2);
+  font-size: 0.73rem;
+  line-height: 1.55;
+  color: var(--bc-ink-3);
+}
+
+.bc-page .bc-quick-note code {
+  font-family: var(--bc-mono);
+  font-size: 0.9em;
+  color: var(--bc-ink);
+}
+
+/* -------------------------------------------------------------------------
+   3i. Doc path cards
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-docs-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.85rem;
+}
+
+.bc-page .bc-doc-card {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 1.05rem 1.05rem 1.15rem;
+  border: 1px solid var(--bc-line);
+  border-radius: var(--bc-r);
+  background: var(--bc-surface);
+  text-decoration: none !important;
+  color: var(--bc-ink-3);
+  transition: border-color var(--bc-fast), box-shadow var(--bc-fast),
+    transform var(--bc-fast);
+}
+
+.bc-page .bc-doc-card:hover {
+  border-color: var(--bc-red);
+  box-shadow: var(--bc-glow);
+  transform: translateY(-2px);
+}
+
+.bc-page .bc-doc-kicker {
+  font-size: 0.61rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--bc-red-ink);
+}
+
+.bc-page .bc-doc-card h3 {
+  margin: 0;
+  font-size: 0.94rem;
+  font-weight: 650;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+  color: var(--bc-ink);
+}
+
+.bc-page .bc-doc-card p {
+  margin: 0.1rem 0 0.7rem;
+  font-size: 0.76rem;
+  line-height: 1.55;
+}
+
+.bc-page .bc-doc-arrow {
+  margin-top: auto;
+  font-family: var(--bc-mono);
+  font-size: 0.73rem;
+  color: var(--bc-red);
+  transition: transform var(--bc-fast);
+}
+
+.bc-page .bc-doc-card:hover .bc-doc-arrow {
+  transform: translateX(3px);
+}
+
+/* -------------------------------------------------------------------------
+   3j. Closing CTA
+   ------------------------------------------------------------------------- */
+
+.bc-page .bc-cta {
+  position: relative;
+  overflow: hidden;
+  padding: clamp(2.5rem, 6vw, 4rem) 0;
+  background: var(--bc-deep);
+  color: var(--bc-deep-ink);
+  border-top: 1px solid var(--bc-deep-line);
+}
+
+.bc-page .bc-cta::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background-image: linear-gradient(
+      to right,
+      rgba(255, 255, 255, 0.05) 1px,
+      transparent 1px
+    ),
+    linear-gradient(to bottom, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+  background-size: 46px 46px;
+  -webkit-mask-image: radial-gradient(
+    ellipse 60% 100% at 50% 0%,
+    #000,
+    transparent 75%
+  );
+  mask-image: radial-gradient(ellipse 60% 100% at 50% 0%, #000, transparent 75%);
+  pointer-events: none;
+}
+
+.bc-page .bc-cta-inner {
+  position: relative;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.5rem;
+}
+
+.bc-page .bc-cta h2 {
+  margin: 0 0 0.4rem;
+  font-size: clamp(1.2rem, 2.4vw, 1.65rem);
+  font-weight: 720;
+  letter-spacing: -0.032em;
+  color: #fff;
+  line-height: 1.15;
+  text-wrap: balance;
+}
+
+.bc-page .bc-cta p {
+  margin: 0;
+  max-width: 32rem;
+  font-size: 0.84rem;
+  line-height: 1.6;
+  color: var(--bc-deep-muted);
+}
+
+.bc-page .bc-cta .bc-cta-row {
+  margin: 0;
+}
+
+.bc-page .bc-cta .bc-btn--ghost {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.28);
+  color: #fff !important;
+}
+
+.bc-page .bc-cta .bc-btn--ghost:hover,
+.bc-page .bc-cta .bc-btn--primary:hover {
+  background: #fff;
+  border-color: #fff;
+  color: var(--bc-deep) !important;
+}
+
+/* =========================================================================
+   4. RESPONSIVE
+   ========================================================================= */
+
+@media screen and (max-width: 76.25em) {
+  .bc-page .bc-docs-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media screen and (max-width: 66em) {
+  .bc-page .bc-hero-inner {
+    grid-template-columns: minmax(0, 1fr);
+    gap: 2.25rem;
+  }
+
+  .bc-page .bc-hero-lede,
+  .bc-page .bc-head {
+    max-width: none;
+  }
+
+  .bc-page .bc-features {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bc-page .bc-quick {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bc-page .bc-stats-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .bc-page .bc-stat:nth-child(3) {
+    border-left: 0;
+    padding-left: 0;
+  }
+
+  .bc-page .bc-stat:nth-child(2) {
+    padding-right: 0;
+  }
+
+  .bc-page .bc-stat:nth-child(n + 3) {
+    border-top: 1px solid var(--bc-line);
+  }
+}
+
+@media screen and (max-width: 56em) {
+  .bc-page .bc-steps {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bc-page .bc-step::after {
+    display: none;
+  }
+}
+
+@media screen and (max-width: 44em) {
+  .bc-page .bc-features,
+  .bc-page .bc-docs-grid,
+  .bc-page .bc-stats-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .bc-page .bc-stat {
+    padding-left: 0;
+    padding-right: 0;
+    border-left: 0;
+    border-top: 1px solid var(--bc-line);
+  }
+
+  .bc-page .bc-stat:first-child {
+    border-top: 0;
+  }
+
+  .bc-page .bc-cta-row .bc-btn {
+    flex: 1 1 100%;
+    justify-content: center;
+  }
+
+  .bc-page .bc-h1 .bc-marked::after {
+    display: none;
+  }
+
+  .md-typeset h1 {
+    font-size: 1.55rem;
+  }
+}
+
+/* =========================================================================
+   5. MOTION + ACCESSIBILITY
+   ========================================================================= */
+
+:where(a, button, .bc-btn, .bc-doc-card, .bc-pill):focus-visible {
+  outline: 2px solid var(--bc-red);
+  outline-offset: 2px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-delay: 0ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+
+  .bc-page .bc-step:hover,
+  .bc-page .bc-doc-card:hover,
+  .bc-page .bc-btn:hover,
+  .bc-page .bc-pill:hover {
+    transform: none;
+  }
+}
+
+.bc-sr {
   position: absolute;
   width: 1px;
   height: 1px;

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,16 +11,22 @@ site_dir: site
 theme:
   name: material
   language: en
+  custom_dir: overrides
   logo: assets/logo-mark.svg
+  favicon: assets/images/favicon.svg
+  font:
+    text: Inter
+    code: JetBrains Mono
   features:
     - navigation.instant
+    - navigation.instant.progress
     - navigation.tracking
     - navigation.tabs
     - navigation.sections
-    - navigation.expand
     - navigation.top
     - navigation.footer
     - navigation.indexes
+    - navigation.prune
     - toc.follow
     - search.suggest
     - search.highlight
@@ -31,6 +37,7 @@ theme:
     - content.action.edit
     - content.action.view
     - content.tooltips
+    - announce.dismiss
   palette:
     - media: "(prefers-color-scheme)"
       toggle:

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -1,0 +1,29 @@
+{% extends "base.html" %}
+
+{% block announce %}
+  <div class="bc-announce">
+    <span class="bc-announce-tag">New</span>
+    <span class="bc-announce-text">
+      BrowserControl 0.1.4 &mdash; ~30 vision-first MCP tools, 100% local.
+    </span>
+    <a class="bc-announce-link"
+       href="{{ 'getting-started/installation/' | url }}">
+      Install it &rarr;
+    </a>
+  </div>
+{% endblock %}
+
+{% block extrahead %}
+  {% set title = config.site_name %}
+  {% if page and page.title and not page.is_homepage %}
+    {% set title = page.title ~ " &middot; " ~ config.site_name %}
+  {% endif %}
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ title }}">
+  <meta property="og:description" content="{{ config.site_description }}">
+  <meta property="og:url" content="{{ page.canonical_url if page else config.site_url }}">
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ title }}">
+  <meta name="twitter:description" content="{{ config.site_description }}">
+  <meta name="theme-color" content="#0b0f16">
+{% endblock %}


### PR DESCRIPTION
## What

The previous redesign styled only the landing page — every other page was stock Material, and the landing page itself was boxed in by Material's content grid. This rebuilds both layers on one token set.

### Global (every page)
- **Type**: Inter + JetBrains Mono.
- **Tokens** for surfaces, ink, lines, accents, elevation, and motion, wired into Material's own CSS variables so the header, tabs, sidebars, code blocks, tables, admonitions, grid cards, and footer inherit the brand instead of being restyled one at a time.
- **Header and tabs** are now a light, translucent toolbar rather than a black slab. Driving `--md-primary-fg/bg-color` turned out to be more reliable than overriding `.md-header`, which the `primary: black` palette targets at higher specificity.
- **Admonitions**: Material colours each variant with `.admonition.<type>`, so the accent rules need one more class to win. All variants are mapped to the violet / teal / amber / red accents.
- Tables fill the measure, category cards land three-up, and the content grid widens to 68rem for the wide tool-reference tables.
- New `overrides/main.html` adds a dismissible announcement bar and OG / Twitter card meta.

### Landing page
- Full-bleed sections — Material caps `.md-main__inner` at 61rem, which was making the hero look like a boxed panel.
- The hero visual is **markup, not a baked SVG**, so the Set of Marks demo follows the reader's colour scheme and stays crisp at any resolution.
- New sections: a stat strip, an agent-session transcript, a three-way comparison against selector-driven MCP servers and hosted browser agents, and a quickstart that pairs install steps with the MCP client config.
- Every landing rule is prefixed with `.bc-page` so Material's `.md-typeset <tag>` rules don't reset the components.

### Copy
The About page's mission line ("Make this MCP server great, popular, well-used") now describes what agents get out of it rather than what the project wants to become.

## Verification

`mkdocs build --strict` passes. Reviewed via full-page Playwright captures at 1440px and 420px, in both light and dark schemes, across the landing page, tool reference, installation, guides, and Set of Marks pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PzitMXLtofF15UrRTd7ayH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Redesigned the homepage with an interactive browser visualization, clearer product narrative, feature highlights, comparison table, quickstart guide, and documentation links.
  - Added installation guidance, MCP client configuration examples, and Chromium troubleshooting information.
  - Updated the Mission section to explain BrowserControl’s goals and guiding principles.
  - Refreshed site navigation, branding, typography, colors, and responsive layouts.
  - Added improved accessibility, keyboard focus indicators, screen-reader support, and reduced-motion behavior.
  - Added announcement messaging and richer social sharing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->