### PR TITLE
docs: add OpenCode to the getting started guide

### DIFF
--- a/docs/getting-started/connect-your-ai.md
+++ b/docs/getting-started/connect-your-ai.md
@@ -65,6 +65,43 @@ Cursor Settings → **Features** → **Model Context Protocol** → Add:
 { "browsercontrol": { "command": "browsercontrol" } }
 ```
 
+## OpenCode
+
+Add to `opencode.json` — project-local, or global at `~/.config/opencode/opencode.json`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "browsercontrol": {
+      "type": "local",
+      "command": ["browsercontrol"],
+      "enabled": true
+    }
+  }
+}
+```
+
+Or let the CLI write it for you:
+
+```bash
+opencode mcp add
+```
+
+Run `opencode mcp list` to confirm BrowserControl is connected. To pass environment variables, use the `environment` key rather than `env`:
+
+```json
+{
+  "mcp": {
+    "browsercontrol": {
+      "type": "local",
+      "command": ["browsercontrol"],
+      "environment": { "BROWSER_HEADLESS": "false" }
+    }
+  }
+}
+```
+
 ## Zed Editor
 
 Add to `~/.config/zed/settings.json`:

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -5,14 +5,14 @@ Welcome to **BrowserControl** — the vision-first browser automation MCP server
 ## What you'll do
 
 1. **[Install BrowserControl](installation.md)** — pip / uv / pipx in one command.
-2. **[Connect it to your AI](connect-your-ai.md)** — Claude Desktop, Cursor, Cline, Continue, Zed, or programmatic Python.
+2. **[Connect it to your AI](connect-your-ai.md)** — Claude Desktop, Cursor, Cline, Continue, OpenCode, Zed, or programmatic Python.
 3. **[Run your first session](first-session.md)** — navigate, click, type, and screenshot.
 4. **[Add the agent skill](agent-skill.md)** _(optional)_ — a playbook that teaches your agent to drive the browser well.
 
 ## What you'll need
 
 - **Python 3.11 or newer** on Linux, macOS, or Windows.
-- **An MCP-compatible AI client** — Claude Desktop, Cursor, Cline, Continue, Gemini CLI, or any client that speaks MCP stdio.
+- **An MCP-compatible AI client** — Claude Desktop, Cursor, Cline, Continue, OpenCode, Gemini CLI, or any client that speaks MCP stdio.
 - **No API key, no cloud account, no telemetry.** BrowserControl runs 100% on your machine.
 
 !!! tip "Already have a Python project?"


### PR DESCRIPTION
## Summary

Adds OpenCode to the getting started guide's supported MCP clients.

- **`docs/getting-started/connect-your-ai.md`** — new OpenCode section (after Cursor, before Zed) documenting the `opencode.json` `mcp` block, the `opencode mcp add` / `opencode mcp list` CLI path, and environment variables.
- **`docs/getting-started/index.md`** — lists OpenCode in the two supported-client rundowns.

## Notes

OpenCode's config schema differs from the `mcpServers` shape every other client on the page uses — it needs `type: "local"`, `command` as an **array**, and env vars under `environment` rather than `env`. The section calls that out explicitly since it's the likely stumbling block for anyone copying a Claude Desktop block across. Config shape was verified against OpenCode's current MCP docs.

Docs-only; no code or test changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Y4f89v2jUVzJ9LdBsYhEGK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added setup instructions for connecting BrowserControl to OpenCode, including project or global configuration options.
  * Documented commands for adding and verifying the BrowserControl connection.
  * Updated getting-started guidance with clearer step numbering and an expanded list of supported MCP clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->