### PR TITLE
chore: gitignore local scratch directories (.claude/, .test-tmp/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ dist/
 # Locally captured screenshots (not referenced by the docs site)
 /assets/live/
 
+# Local scratch directories (not committed)
+.claude/
+.test-tmp/
+
 # OS
 .DS_Store
 Thumbs.db


### PR DESCRIPTION
## Problem

Two untracked directories in the working tree are at risk of being committed by accident:

- `.claude/` — local Claude Code settings (per-machine, not portable across contributors)
- `.test-tmp/` — 819 LOC of one-off scratch test scripts that fail project lint and have no canonical home under `tests/`

Neither was listed in `.gitignore`. A `git add .` from a clean checkout would pick them up.

## Change

Add both directories to `.gitignore` under a new "Local scratch directories (not committed)" block.

No source files touched. Docs site unchanged.

## Verification

```
$ uv run mkdocs build --strict
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.50 seconds

$ uv run ruff check .
All checks passed!

$ uv run ruff format --check .
25 files already formatted

$ uv run pytest -q
======================= 100 passed, 27 warnings in 1.18s =======================
```

Full CI matrix (lint, test, security, type-check, test-windows, test-macos, docs deploy) runs on the PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Excluded local scratch directories from version control tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->